### PR TITLE
Changed exteriorColorHex property of Vehicle to optional String

### DIFF
--- a/Sources/PorscheConnect/Models.swift
+++ b/Sources/PorscheConnect/Models.swift
@@ -60,14 +60,18 @@ public struct Vehicle: Codable {
   public let modelDescription: String
   public let modelType: String
   public let modelYear: String
-  public let exteriorColorHex: String
+  public let exteriorColor: String?
+  public let exteriorColorHex: String?
   public let attributes: [VehicleAttribute]?
   public let pictures: [VehiclePicture]?
   
   // MARK: Computed Properties
   
-  public var externalColor: Color {
-    return Color(hex: exteriorColorHex)
+  public var color: Color? {
+    if let hex = exteriorColorHex {
+      return Color(hex: hex)
+    }
+    return nil
   }
   
   // MARK: -
@@ -102,6 +106,7 @@ public struct Vehicle: Codable {
     self.modelDescription = modelDescription
     self.modelType = modelType
     self.modelYear = modelYear
+    self.exteriorColor = kBlankString
     self.exteriorColorHex = exteriorColorHex
     self.attributes = attributes
     self.pictures = pictures
@@ -112,6 +117,7 @@ public struct Vehicle: Codable {
     self.modelDescription = modelDescription
     self.modelType = modelType
     self.modelYear = modelYear
+    self.exteriorColor = kBlankString
     self.exteriorColorHex = kBlankString
     self.attributes = nil
     self.pictures = nil
@@ -122,6 +128,7 @@ public struct Vehicle: Codable {
     self.modelDescription = kBlankString
     self.modelType = kBlankString
     self.modelYear = kBlankString
+    self.exteriorColor = kBlankString
     self.exteriorColorHex = kBlankString
     self.attributes = nil
     self.pictures = nil


### PR DESCRIPTION
Created this PR because for my account `exteriorColorHex` is null and Vehicle class was of type String.

Example response:
```
  "modelDescription": "Taycan 4 Cross Turismo",
  "exteriorColor": "cherrymetallic/cherrymetallic",
  "exteriorColorHex": null,
```