### PR TITLE
weekDays property in Timer needs to be optional

### DIFF
--- a/Sources/PorscheConnect/Models.swift
+++ b/Sources/PorscheConnect/Models.swift
@@ -375,7 +375,7 @@ public struct Emobility: Codable {
     public let preferredChargingEndTime: String?
     public let frequency: String
     public let climatised: Bool
-    public let weekDays: Weekdays
+    public let weekDays: Weekdays?
     public let active: Bool
     public let chargeOption: Bool
     public let targetChargeLevel: Int

--- a/Tests/PorscheConnectTests/ModelsTests.swift
+++ b/Tests/PorscheConnectTests/ModelsTests.swift
@@ -368,14 +368,15 @@ final class ModelsTests: XCTestCase {
     XCTAssertFalse(timer.climatisationTimer)
     
     XCTAssertNotNil(timer.weekDays)
-    let weekdays = timer.weekDays
-    XCTAssertTrue(weekdays.SUNDAY)
-    XCTAssertTrue(weekdays.MONDAY)
-    XCTAssertTrue(weekdays.TUESDAY)
-    XCTAssertTrue(weekdays.WEDNESDAY)
-    XCTAssertTrue(weekdays.THURSDAY)
-    XCTAssertTrue(weekdays.FRIDAY)
-    XCTAssertTrue(weekdays.SATURDAY)
+    if let weekdays = timer.weekDays {
+      XCTAssertTrue(weekdays.SUNDAY)
+      XCTAssertTrue(weekdays.MONDAY)
+      XCTAssertTrue(weekdays.TUESDAY)
+      XCTAssertTrue(weekdays.WEDNESDAY)
+      XCTAssertTrue(weekdays.THURSDAY)
+      XCTAssertTrue(weekdays.FRIDAY)
+      XCTAssertTrue(weekdays.SATURDAY)
+    }
   }
   
   // MARK: - Flash & Honk

--- a/Tests/PorscheConnectTests/PorscheConnect+CarControlTests.swift
+++ b/Tests/PorscheConnectTests/PorscheConnect+CarControlTests.swift
@@ -603,14 +603,15 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(timer.climatisationTimer)
     
     XCTAssertNotNil(timer.weekDays)
-    let weekdays = timer.weekDays
-    XCTAssertTrue(weekdays.SUNDAY)
-    XCTAssertTrue(weekdays.MONDAY)
-    XCTAssertTrue(weekdays.TUESDAY)
-    XCTAssertTrue(weekdays.WEDNESDAY)
-    XCTAssertTrue(weekdays.THURSDAY)
-    XCTAssertTrue(weekdays.FRIDAY)
-    XCTAssertTrue(weekdays.SATURDAY)
+    if let weekdays = timer.weekDays {
+      XCTAssertTrue(weekdays.SUNDAY)
+      XCTAssertTrue(weekdays.MONDAY)
+      XCTAssertTrue(weekdays.TUESDAY)
+      XCTAssertTrue(weekdays.WEDNESDAY)
+      XCTAssertTrue(weekdays.THURSDAY)
+      XCTAssertTrue(weekdays.FRIDAY)
+      XCTAssertTrue(weekdays.SATURDAY)
+    }
   }
   
   private func assertEmobilityWhenACTimerCharging(_ emobility: Emobility) {
@@ -728,14 +729,15 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(timer.climatisationTimer)
     
     XCTAssertNotNil(timer.weekDays)
-    let weekdays = timer.weekDays
-    XCTAssertTrue(weekdays.SUNDAY)
-    XCTAssertTrue(weekdays.MONDAY)
-    XCTAssertTrue(weekdays.TUESDAY)
-    XCTAssertTrue(weekdays.WEDNESDAY)
-    XCTAssertTrue(weekdays.THURSDAY)
-    XCTAssertTrue(weekdays.FRIDAY)
-    XCTAssertTrue(weekdays.SATURDAY)
+    if let weekdays = timer.weekDays {
+      XCTAssertTrue(weekdays.SUNDAY)
+      XCTAssertTrue(weekdays.MONDAY)
+      XCTAssertTrue(weekdays.TUESDAY)
+      XCTAssertTrue(weekdays.WEDNESDAY)
+      XCTAssertTrue(weekdays.THURSDAY)
+      XCTAssertTrue(weekdays.FRIDAY)
+      XCTAssertTrue(weekdays.SATURDAY)
+    }
   }
   
   private func assertEmobilityWhenACDirectCharging(_ emobility: Emobility) {
@@ -853,14 +855,15 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(timer.climatisationTimer)
     
     XCTAssertNotNil(timer.weekDays)
-    let weekdays = timer.weekDays
-    XCTAssertTrue(weekdays.SUNDAY)
-    XCTAssertTrue(weekdays.MONDAY)
-    XCTAssertTrue(weekdays.TUESDAY)
-    XCTAssertTrue(weekdays.WEDNESDAY)
-    XCTAssertTrue(weekdays.THURSDAY)
-    XCTAssertTrue(weekdays.FRIDAY)
-    XCTAssertTrue(weekdays.SATURDAY)
+    if let weekdays = timer.weekDays {
+      XCTAssertTrue(weekdays.SUNDAY)
+      XCTAssertTrue(weekdays.MONDAY)
+      XCTAssertTrue(weekdays.TUESDAY)
+      XCTAssertTrue(weekdays.WEDNESDAY)
+      XCTAssertTrue(weekdays.THURSDAY)
+      XCTAssertTrue(weekdays.FRIDAY)
+      XCTAssertTrue(weekdays.SATURDAY)
+    }
   }
   
   private func assertEmobilityWhenDCCharging(_ emobility: Emobility) {
@@ -978,14 +981,15 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(timer.climatisationTimer)
     
     XCTAssertNotNil(timer.weekDays)
-    let weekdays = timer.weekDays
-    XCTAssertTrue(weekdays.SUNDAY)
-    XCTAssertTrue(weekdays.MONDAY)
-    XCTAssertTrue(weekdays.TUESDAY)
-    XCTAssertTrue(weekdays.WEDNESDAY)
-    XCTAssertTrue(weekdays.THURSDAY)
-    XCTAssertTrue(weekdays.FRIDAY)
-    XCTAssertTrue(weekdays.SATURDAY)
+    if let weekdays = timer.weekDays {
+      XCTAssertTrue(weekdays.SUNDAY)
+      XCTAssertTrue(weekdays.MONDAY)
+      XCTAssertTrue(weekdays.TUESDAY)
+      XCTAssertTrue(weekdays.WEDNESDAY)
+      XCTAssertTrue(weekdays.THURSDAY)
+      XCTAssertTrue(weekdays.FRIDAY)
+      XCTAssertTrue(weekdays.SATURDAY)
+    }
   }
   
   private func assertRemoteCommandAccepted(_ remoteCommandAccepted: RemoteCommandAccepted) {


### PR DESCRIPTION
Timers array for me looks like this:

```
"timers": [{
    "timerID": "1",
    "departureDateTime": "2022-12-28T10:30:00.000Z",
    "preferredChargingTimeEnabled": false,
    "preferredChargingStartTime": null,
    "preferredChargingEndTime": null,
    "frequency": "SINGLE",
    "climatised": true,
    "weekDays": null,
    "active": false,
    "chargeOption": true,
    "targetChargeLevel": 100,
    "e3_CLIMATISATION_TIMER_ID": "4",
    "climatisationTimer": false
  }],
```