### PR TITLE
Ran all source files through Xcode's auto-formatter.

### DIFF
--- a/Sources/CommandLineTool/Command+Flash.swift
+++ b/Sources/CommandLineTool/Command+Flash.swift
@@ -23,9 +23,9 @@ extension Porsche {
     }
 
     // MARK: - Private functions
-    
+
     private func callFlash(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
-      
+
       do {
         let result = try await porscheConnect.flash(vehicle: vehicle)
         if let remoteCommandAccepted = result.remoteCommandAccepted {
@@ -36,7 +36,7 @@ extension Porsche {
         Porsche.Flash.exit(withError: error)
       }
     }
-    
+
     private func printRemoteCommandAccepted(_ remoteCommandAccepted: RemoteCommandAccepted) {
       print(NSLocalizedString("Remote command \"Flash\" accepted by Porsche API with ID \(remoteCommandAccepted.id)", comment: ""))
     }

--- a/Sources/CommandLineTool/Command+HonkAndFlash.swift
+++ b/Sources/CommandLineTool/Command+HonkAndFlash.swift
@@ -3,28 +3,28 @@ import ArgumentParser
 import PorscheConnect
 
 extension Porsche {
-  
+
   struct HonkAndFlash: AsyncParsableCommand {
     // MARK: - Properties
-    
+
     @OptionGroup() var options: Options
-    
+
     @Argument(help: ArgumentHelp(NSLocalizedString("Your vehicle VIN.", comment: "")))
     var vin: String
-    
+
     // MARK: - Lifecycle
-    
+
     func run() async throws {
       let porscheConnect = PorscheConnect(username: options.username, password: options.password)
       let vehicle = Vehicle(vin: vin)
       await callHonkAndFlash(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()
     }
-    
+
     // MARK: - Private functions
-    
+
     private func callHonkAndFlash(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
-      
+
       do {
         let result = try await porscheConnect.flash(vehicle: vehicle, andHonk: true)
         if let remoteCommandAccepted = result.remoteCommandAccepted {
@@ -35,7 +35,7 @@ extension Porsche {
         Porsche.HonkAndFlash.exit(withError: error)
       }
     }
-    
+
     private func printRemoteCommandAccepted(_ remoteCommandAccepted: RemoteCommandAccepted) {
       print(NSLocalizedString("Remote command \"Honk and Flash\" accepted by Porsche API with ID \(remoteCommandAccepted.id)", comment: ""))
     }

--- a/Sources/CommandLineTool/Command+ListVehicles.swift
+++ b/Sources/CommandLineTool/Command+ListVehicles.swift
@@ -3,24 +3,24 @@ import ArgumentParser
 import PorscheConnect
 
 extension Porsche {
-    
+
   struct ListVehicles: AsyncParsableCommand {
-    
+
     // MARK: - Properties
-    
+
     @OptionGroup() var options: Options
-    
+
     // MARK: - Lifecycle
-    
+
     func run() async throws {
       let porscheConnect = PorscheConnect(username: options.username, password: options.password)
       await callListVehiclesService(porscheConnect: porscheConnect)
       dispatchMain()
     }
-    
+
     // MARK: - Private functions
-    
-    private func callListVehiclesService(porscheConnect: PorscheConnect) async {      
+
+    private func callListVehiclesService(porscheConnect: PorscheConnect) async {
       do {
         let result = try await porscheConnect.vehicles()
         printVehicles(result.vehicles)
@@ -29,15 +29,15 @@ extension Porsche {
         Porsche.ListVehicles.exit(withError: error)
       }
     }
-    
+
     private func printVehicles(_ vehicles: [Vehicle]?) {
       guard let vehicles = vehicles else { return }
-      
+
       vehicles.enumerated().forEach { (index, vehicle) in
         printVehicle(vehicle, at: index)
       }
     }
-    
+
     private func printVehicle(_ vehicle: Vehicle, at index: Int) {
       let output = NSLocalizedString("#\(index+1) => Model: \(vehicle.modelDescription); Year: \(vehicle.modelYear); Type: \(vehicle.modelType); VIN: \(vehicle.vin)", comment: "")
       print(output)

--- a/Sources/CommandLineTool/Command+ShowCapabilities.swift
+++ b/Sources/CommandLineTool/Command+ShowCapabilities.swift
@@ -3,29 +3,29 @@ import ArgumentParser
 import PorscheConnect
 
 extension Porsche {
-  
+
   struct ShowCapabilities: AsyncParsableCommand {
-    
+
     // MARK: - Properties
-    
+
     @OptionGroup() var options: Options
-    
+
     @Argument(help: ArgumentHelp(NSLocalizedString("Your vehicle VIN.", comment: "")))
     var vin: String
-    
+
     // MARK: - Lifecycle
-    
+
     func run() async throws {
       let porscheConnect = PorscheConnect(username: options.username, password: options.password)
       let vehicle = Vehicle(vin: vin)
       await callCapabilitiesService(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()
     }
-    
+
     // MARK: - Private functions
-    
+
     private func callCapabilitiesService(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
-      
+
       do {
         let result = try await porscheConnect.capabilities(vehicle: vehicle)
         if let capabilities = result.capabilities {
@@ -35,7 +35,7 @@ extension Porsche {
         Porsche.ShowEmobility.exit(withError: error)
       }
     }
-    
+
     private func printCapabilities(_ capabilities: Capabilities) {
       let output = NSLocalizedString("Display parking brake: \(capabilities.displayParkingBrake.displayString); Needs SPIN: \(capabilities.needsSPIN.displayString); Has RDK: \(capabilities.hasRDK.displayString); Engine Type: \(capabilities.engineType); Car Model: \(capabilities.carModel); Front Seat Heating: \(capabilities.heatingCapabilities.frontSeatHeatingAvailable.displayString); Rear Seat Heating: \(capabilities.heatingCapabilities.rearSeatHeatingAvailable.displayString); Steering Wheel Position: \(capabilities.steeringWheelPosition); Honk & Flash: \(capabilities.hasHonkAndFlash.displayString)", comment: "")
       print(output)

--- a/Sources/CommandLineTool/Command+ShowEmobility.swift
+++ b/Sources/CommandLineTool/Command+ShowEmobility.swift
@@ -3,27 +3,27 @@ import ArgumentParser
 import PorscheConnect
 
 extension Porsche {
-  
+
   struct ShowEmobility: AsyncParsableCommand {
-    
+
     // MARK: - Properties
-    
+
     @OptionGroup() var options: Options
-    
+
     @Argument(help: ArgumentHelp(NSLocalizedString("Your vehicle VIN.", comment: "")))
     var vin: String
-    
+
     // MARK: - Lifecycle
-    
+
     func run() async throws {
       let porscheConnect = PorscheConnect(username: options.username, password: options.password)
       let vehicle = Vehicle(vin: vin)
       await callCapabilitiesService(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()
     }
-    
+
     // MARK: - Private functions
-    
+
     private func callCapabilitiesService(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
       do {
         let result = try await porscheConnect.capabilities(vehicle: vehicle)
@@ -32,10 +32,10 @@ extension Porsche {
         Porsche.ShowEmobility.exit(withError: error)
       }
     }
-    
+
     private func callEmobilityService(porscheConnect: PorscheConnect, vehicle: Vehicle, capabilities: Capabilities?) async {
       guard let capabilities = capabilities else { return }
-      
+
       do {
         let result = try await porscheConnect.emobility(vehicle: vehicle, capabilities: capabilities)
         if let emobility = result.emobility {
@@ -46,7 +46,7 @@ extension Porsche {
         Porsche.ShowEmobility.exit(withError: error)
       }
     }
-    
+
     private func printEmobility(_ emobility: Emobility) {
       let output = NSLocalizedString("Battery Level: \(emobility.batteryChargeStatus.stateOfChargeInPercentage)%; Remaining Range: \(emobility.batteryChargeStatus.remainingERange.valueInKilometers) KM; Charging Status: \(emobility.chargingStatus); Plug Status: \(emobility.batteryChargeStatus.plugState)", comment: "")
       print(output)

--- a/Sources/CommandLineTool/Command+ShowPosition.swift
+++ b/Sources/CommandLineTool/Command+ShowPosition.swift
@@ -3,27 +3,27 @@ import ArgumentParser
 import PorscheConnect
 
 extension Porsche {
-  
+
   struct ShowPosition: AsyncParsableCommand {
-    
+
     // MARK: - Properties
-    
+
     @OptionGroup() var options: Options
-    
+
     @Argument(help: ArgumentHelp(NSLocalizedString("Your vehicle VIN.", comment: "")))
     var vin: String
-    
+
     // MARK: - Lifecycle
-    
+
     func run() async throws {
       let porscheConnect = PorscheConnect(username: options.username, password: options.password)
       let vehicle = Vehicle(vin: vin)
       await callPositionService(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()
     }
-    
+
     // MARK: - Private functions
-    
+
     private func callPositionService(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
       do {
         let result = try await porscheConnect.position(vehicle: vehicle)
@@ -35,7 +35,7 @@ extension Porsche {
         Porsche.ShowPosition.exit(withError: error)
       }
     }
-    
+
     private func printPosition(_ position: Position) {
       let output = NSLocalizedString("Latitude: \(position.carCoordinate.latitude); Longitude: \(position.carCoordinate.longitude); Heading: \(String(format: "%.0f" ,position.heading))", comment: "")
       print(output)

--- a/Sources/CommandLineTool/Command+ShowSummary.swift
+++ b/Sources/CommandLineTool/Command+ShowSummary.swift
@@ -3,28 +3,28 @@ import ArgumentParser
 import PorscheConnect
 
 extension Porsche {
-  
+
   struct ShowSummary: AsyncParsableCommand {
     // MARK: - Properties
-    
+
     @OptionGroup() var options: Options
-    
+
     @Argument(help: ArgumentHelp(NSLocalizedString("Your vehicle VIN.", comment: "")))
     var vin: String
-    
+
     // MARK: - Lifecycle
-    
+
     func run() async throws {
       let porscheConnect = PorscheConnect(username: options.username, password: options.password)
       let vehicle = Vehicle(vin: vin)
       await callSummaryService(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()
     }
-    
+
     // MARK: - Private functions
-    
+
     private func callSummaryService(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
-      
+
       do {
         let result = try await porscheConnect.summary(vehicle: vehicle)
         if let summary = result.summary {
@@ -35,7 +35,7 @@ extension Porsche {
         Porsche.ShowSummary.exit(withError: error)
       }
     }
-    
+
     private func printSummary(_ summary: Summary) {
       let output = NSLocalizedString("Model Description: \(summary.modelDescription); Nickname: \(summary.nickName ?? "None")", comment: "")
       print(output)

--- a/Sources/CommandLineTool/Porsche.swift
+++ b/Sources/CommandLineTool/Porsche.swift
@@ -9,11 +9,11 @@ struct Porsche: AsyncParsableCommand {
     abstract: NSLocalizedString("A command-line tool to call and interact with Porsche Connect services.", comment: ""),
     version: "0.1.4",
     subcommands: [ListVehicles.self, ShowSummary.self, ShowPosition.self, ShowCapabilities.self, ShowEmobility.self, Flash.self, HonkAndFlash.self])
-  
+
   struct Options: ParsableArguments {
     @Argument(help: ArgumentHelp(NSLocalizedString("Your MyPorsche username (registered email).", comment: "")))
     var username: String
-    
+
     @Argument(help: ArgumentHelp(NSLocalizedString("Your MyPorsche password.", comment: "")))
     var password: String
   }

--- a/Sources/PorscheConnect/Constants.swift
+++ b/Sources/PorscheConnect/Constants.swift
@@ -20,7 +20,7 @@ enum HttpStatusCode: Int, Error {
   case Continue = 100
   case SwitchingProtocols
   case Processing
-  
+
   // 200 Success
   case OK = 200
   case Created
@@ -32,7 +32,7 @@ enum HttpStatusCode: Int, Error {
   case MultiStatus
   case AlreadyReported
   case IMUsed = 226
-  
+
   // 300 Redirection
   case MultipleChoices = 300
   case MovedPermanently
@@ -43,7 +43,7 @@ enum HttpStatusCode: Int, Error {
   case SwitchProxy
   case TemporaryRedirect
   case PermanentRedirect
-  
+
   // 400 Client Error
   case BadRequest = 400
   case Unauthorized
@@ -73,7 +73,7 @@ enum HttpStatusCode: Int, Error {
   case TooManyRequests
   case RequestHeaderFieldsTooLarge = 431
   case UnavailableForLegalReasons = 451
-  
+
   // 500 Server Error
   case InternalServerError = 500
   case NotImplemented
@@ -86,7 +86,7 @@ enum HttpStatusCode: Int, Error {
   case LoopDetected
   case NotExtended = 510
   case NetworkAuthenticationRequired
-  
+
   var localizedDescription: String {
     return String(rawValue)
   }

--- a/Sources/PorscheConnect/Extensions.swift
+++ b/Sources/PorscheConnect/Extensions.swift
@@ -18,7 +18,7 @@ extension Color {
     default:
       (a, r, g, b) = (1, 1, 1, 0)
     }
-    
+
     self.init(
       .sRGB,
       red: Double(r) / 255,
@@ -36,10 +36,10 @@ extension URL {
     guard let params = params else {
       return self
     }
-    
+
     var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: true)!
     var queryItems = [URLQueryItem]()
-    
+
     let existingQueryItems = query?.components(separatedBy: "&").map({
       $0.components(separatedBy: "=")
     }).reduce(into: [URLQueryItem](), { queryItems, pair in
@@ -47,17 +47,17 @@ extension URL {
         queryItems.append(URLQueryItem(name: pair[0], value: pair[1]))
       }
     })
-    
+
     if let existingQueryItems = existingQueryItems {
       queryItems.append(contentsOf: existingQueryItems)
     }
-    
+
     for (key, value) in params {
       queryItems.append(URLQueryItem(name: key, value: value))
     }
-    
+
     urlComponents.queryItems = queryItems
-    
+
     return urlComponents.url!
   }
 }

--- a/Sources/PorscheConnect/Models.swift
+++ b/Sources/PorscheConnect/Models.swift
@@ -3,19 +3,19 @@ import SwiftUI
 import CoreLocation
 
 public struct PorscheAuth: Codable {
-  
+
   // MARK: Properties
-  
+
   public let accessToken: String
   public let idToken: String
   public let tokenType: String
   public let expiresIn: Double
   public let expiresAt: Date
-  
+
   public var apiKey: String? {
     let idTokenComponents = idToken.components(separatedBy: ".")
     let paddedBase64EncodedString = idTokenComponents[1].padding(toLength: ((idTokenComponents[1].count+3)/4)*4, withPad: "=", startingAt: 0)
-    
+
     if let decodedString = String(data: Data(base64Encoded: paddedBase64EncodedString) ?? kBlankData, encoding: .utf8),
        let data = decodedString.data(using: .utf8),
        let dict = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? Dictionary<String, Any>,
@@ -25,13 +25,13 @@ public struct PorscheAuth: Codable {
       return nil
     }
   }
-  
+
   public var expired: Bool {
     return Date() > expiresAt
   }
-  
+
   // MARK: Lifecycle
-  
+
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     self.accessToken = try values.decode(String.self, forKey: .accessToken)
@@ -40,7 +40,7 @@ public struct PorscheAuth: Codable {
     self.expiresIn = try values.decode(Double.self, forKey: .expiresIn)
     self.expiresAt = Date().addingTimeInterval(self.expiresIn)
   }
-  
+
   public init(accessToken: String, idToken: String, tokenType: String, expiresIn: Double) {
     self.accessToken = accessToken
     self.idToken = idToken
@@ -53,9 +53,9 @@ public struct PorscheAuth: Codable {
 // MARK: -
 
 public struct Vehicle: Codable {
-  
+
   // MARK: Properties
-  
+
   public let vin: String
   public let modelDescription: String
   public let modelType: String
@@ -64,32 +64,32 @@ public struct Vehicle: Codable {
   public let exteriorColorHex: String?
   public let attributes: [VehicleAttribute]?
   public let pictures: [VehiclePicture]?
-  
+
   // MARK: Computed Properties
-  
+
   public var color: Color? {
     if let hex = exteriorColorHex {
       return Color(hex: hex)
     }
     return nil
   }
-  
+
   // MARK: -
-  
+
   public struct VehicleAttribute: Codable {
-    
+
     // MARK: Properties
-    
+
     public let name: String
     public let value: String
   }
-  
+
   // MARK: -
-  
+
   public struct VehiclePicture: Codable {
-    
+
     // MARK: Properties
-    
+
     public let url: URL
     public let view: String
     public let size: Int
@@ -98,9 +98,9 @@ public struct Vehicle: Codable {
     public let transparent: Bool
     public let placeholder: String?
   }
-  
+
   // MARK: - Public
-  
+
   public init(vin: String, modelDescription: String, modelType: String, modelYear: String, exteriorColor: String?, exteriorColorHex: String?, attributes: [VehicleAttribute]?, pictures: [VehiclePicture]?) {
     self.vin = vin
     self.modelDescription = modelDescription
@@ -111,7 +111,7 @@ public struct Vehicle: Codable {
     self.attributes = attributes
     self.pictures = pictures
   }
-  
+
   public init(vin: String, modelDescription: String, modelType: String, modelYear: String) {
     self.vin = vin
     self.modelDescription = modelDescription
@@ -122,7 +122,7 @@ public struct Vehicle: Codable {
     self.attributes = nil
     self.pictures = nil
   }
-  
+
   public init(vin: String) {
     self.vin = vin
     self.modelDescription = kBlankString
@@ -138,9 +138,9 @@ public struct Vehicle: Codable {
 // MARK: -
 
 public struct Summary: Codable {
-  
+
   // MARK: Properties
-  
+
   public let modelDescription: String
   public let nickName: String?
 }
@@ -148,18 +148,18 @@ public struct Summary: Codable {
 // MARK: -
 
 public struct Position: Codable {
-  
+
   // MARK: Properties
-  
+
   public let carCoordinate: CarCoordinate
   public let heading: CLLocationDirection
-  
+
   // MARK: -
-  
+
   public struct CarCoordinate: Codable {
-    
+
     // MARK: Properties
-    
+
     public let geoCoordinateSystem: String
     public let latitude: CLLocationDegrees
     public let longitude: CLLocationDegrees
@@ -169,9 +169,9 @@ public struct Position: Codable {
 // MARK: -
 
 public struct Capabilities: Codable {
-  
+
   // MARK: Properties
-  
+
   public let displayParkingBrake: Bool
   public let needsSPIN: Bool
   public let hasRDK: Bool
@@ -181,43 +181,43 @@ public struct Capabilities: Codable {
   public let heatingCapabilities: HeatingCapabilities
   public let steeringWheelPosition: String
   public let hasHonkAndFlash: Bool
-  
+
   // MARK: -
-  
+
   public struct OnlineRemoteUpdateStatus: Codable {
-    
+
     // MARK: Properties
-    
+
     public let editableByUser: Bool
     public let active: Bool
-    
+
     // MARK: - Public
-    
+
     public init(editableByUser: Bool, active: Bool) {
       self.editableByUser = editableByUser
       self.active = active
     }
   }
-  
+
   // MARK: -
-  
+
   public struct HeatingCapabilities: Codable {
-    
+
     // MARK: Properties
-    
+
     public let frontSeatHeatingAvailable: Bool
     public let rearSeatHeatingAvailable: Bool
-    
+
     // MARK: - Public
-    
+
     public init(frontSeatHeatingAvailable: Bool, rearSeatHeatingAvailable: Bool) {
       self.frontSeatHeatingAvailable = frontSeatHeatingAvailable
       self.rearSeatHeatingAvailable = rearSeatHeatingAvailable
     }
   }
-  
+
   // MARK: - Public
-  
+
   public init(engineType: String, carModel: String) {
     self.displayParkingBrake = false
     self.needsSPIN = false
@@ -234,9 +234,9 @@ public struct Capabilities: Codable {
 // MARK: -
 
 public struct Emobility: Codable {
-  
+
   // MARK: Properties
-  
+
   public let batteryChargeStatus: BatteryChargeStatus
   public let directCharge: DirectCharge
   public let directClimatisation: DirectClimatisation
@@ -244,13 +244,13 @@ public struct Emobility: Codable {
   public let chargingProfiles: ChargingProfiles
   public let climateTimer: String? // TBD when set
   public let timers: [Timer]?
-  
+
   // MARK: -
-  
+
   public struct BatteryChargeStatus: Codable {
-    
+
     // MARK: Properties
-    
+
     public let plugState: String
     public let lockState: String
     public let chargingState: String
@@ -268,13 +268,13 @@ public struct Emobility: Codable {
     public let chargeRate: ChargeRate
     public let chargingPower: Double
     public let chargingInDCMode: Bool
-    
+
     // MARK: -
-    
+
     public struct RemainingERange: Codable {
-      
+
       // MARK: Properties
-      
+
       public let value: Int
       public let unit: String
       public let originalValue: Int
@@ -282,92 +282,92 @@ public struct Emobility: Codable {
       public let valueInKilometers: Int
       public let unitTranslationKey: String
     }
-    
+
     // MARK: -
-    
+
     public struct ChargeRate: Codable {
-      
+
       // MARK: Properties
-      
+
       public let value: Double
       public let unit: String
       public let valueInKmPerHour: Int
       public let unitTranslationKey: String // "EC.COMMON.UNIT.KM_PER_MIN"
     }
   }
-  
+
   // MARK: -
-  
+
   public struct DirectCharge: Codable {
-    
+
     // MARK: Properties
-    
+
     public let disabled: Bool
     public let isActive: Bool
   }
-  
+
   // MARK: -
-  
+
   public struct DirectClimatisation: Codable {
-    
+
     // MARK: Properties
-    
+
     public let climatisationState: String
     public let remainingClimatisationTime: String? // TBD when set
   }
-  
+
   // MARK: -
-  
+
   public struct ChargingProfiles: Codable {
-    
+
     // MARK: Properties
-    
+
     public let currentProfileId: Int
     public let profiles: [Profile]
   }
-  
+
   // MARK: -
-  
+
   public struct Profile: Codable {
-    
+
     // MARK: Properties
-    
+
     public let profileId: Int
     public let profileName: String
     public let profileActive: Bool
     public let chargingOptions: ChargingOptions
     public let position: Position
-    
+
     // MARK: -
-    
+
     public struct ChargingOptions: Codable {
-      
+
       // MARK: Properties
-      
+
       public let minimumChargeLevel: Int
       public let smartChargingEnabled: Bool
       public let preferredChargingEnabled: Bool
       public let preferredChargingTimeStart: String
       public let preferredChargingTimeEnd: String
     }
-    
+
     // MARK: -
-    
+
     public struct Position: Codable {
-      
+
       // MARK: Properties
-      
+
       public let latitude: CLLocationDegrees
       public let longitude: CLLocationDegrees
     }
   }
-  
+
   // MARK: -
-  
+
   public struct Timer: Codable {
-    
+
     // MARK: Properties
-    
+
     public let timerID: String
     public let departureDateTime: String
     public let preferredChargingTimeEnabled: Bool
@@ -380,13 +380,13 @@ public struct Emobility: Codable {
     public let chargeOption: Bool
     public let targetChargeLevel: Int
     public let climatisationTimer: Bool
-    
+
     // MARK: -
-    
+
     public struct Weekdays: Codable {
-      
+
       // MARK: Properties
-      
+
       public let SUNDAY: Bool
       public let MONDAY: Bool
       public let TUESDAY: Bool
@@ -407,7 +407,7 @@ public struct RemoteCommandAccepted: Codable {
   }
 
   // MARK: Properties
-  
+
   public let id: String
   public let lastUpdated: Date
   public var remoteCommand: RemoteCommand?
@@ -420,9 +420,9 @@ public struct RemoteCommandStatus: Codable {
     case inProgress = "IN_PROGRESS"
     case success = "SUCCESS"
   }
-  
+
   // MARK: Properties
-  
+
   public let status: String
 
   // MARK: Computed Properties

--- a/Sources/PorscheConnect/NetworkClient.swift
+++ b/Sources/PorscheConnect/NetworkClient.swift
@@ -4,7 +4,7 @@ import Foundation
 
 struct NetworkClient {
   private let session: URLSession
-  
+
   init(timeoutIntervalForRequest:TimeInterval = 30) {
     let configuration = URLSessionConfiguration.default
     configuration.httpCookieAcceptPolicy = .always
@@ -12,21 +12,21 @@ struct NetworkClient {
     configuration.timeoutIntervalForRequest = timeoutIntervalForRequest
     session = URLSession(configuration: configuration)
   }
-  
+
   // MARK: - Public
-  
+
   func get<D: Decodable>(_ responseType: D.Type, url: URL, params: Dictionary<String, String>? = nil, headers: Dictionary<String, String>? = nil, parseResponseBody: Bool = true, jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = .convertFromSnakeCase) async throws -> (data: D?, response: HTTPURLResponse?) {
     let request = createRequest(url: url.addParams(params: params), method: HttpMethod.get.rawValue, headers: headers, contentType: .json, bodyData: nil)
     return try await performRequest(responseType, request: request, parseResponseBody: parseResponseBody, jsonKeyDecodingStrategy: jsonKeyDecodingStrategy)
   }
-  
+
   func post<E: Encodable, D: Decodable>(_ responseType: D.Type, url: URL, params: Dictionary<String, String>? = nil, body: E?, headers: Dictionary<String, String>? = nil, contentType: HttpRequestContentType = .json, parseResponseBody: Bool = true, jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = .convertFromSnakeCase) async throws -> (data: D?, response: HTTPURLResponse?) {
     let request = buildModifyingRequest(url: url.addParams(params: params), method: HttpMethod.post.rawValue, headers: headers, contentType: contentType, body: body)
     return try await performRequest(responseType, request: request, contentType: contentType, parseResponseBody: parseResponseBody, jsonKeyDecodingStrategy: jsonKeyDecodingStrategy)
   }
-  
+
   // MARK: - Private
-  
+
   private func createRequest(url: URL, method: String, headers: Dictionary<String, String>?, contentType: HttpRequestContentType, bodyData: Data?) -> URLRequest {
     var request = URLRequest(url: url)
     request.httpMethod = method
@@ -35,33 +35,33 @@ struct NetworkClient {
         request.addValue(value, forHTTPHeaderField: key)
       }
     }
-    
+
     request.addValue(contentType.mimeDescription, forHTTPHeaderField: "Content-Type")
     request.httpBody = bodyData
     return request
   }
-  
+
   private func performRequest<D: Decodable>(_ responseType: D.Type, request: URLRequest, contentType: HttpRequestContentType = .json, parseResponseBody: Bool = true, jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = .convertFromSnakeCase) async throws -> (D?, HTTPURLResponse?) {
     return try await withCheckedThrowingContinuation { continuation in
       let task = session.dataTask(with: request) { (data, urlResponse, error) in
         let response = urlResponse as? HTTPURLResponse
-        
+
         if let response = response {
           if isErrorStatusCode(response) {
             continuation.resume(with: .failure(HttpStatusCode(rawValue: response.statusCode)!))
             return
           }
         }
-        
+
         guard let data1 = data, error == nil, !data1.isEmpty, parseResponseBody else {
           continuation.resume(with: .success((nil, response)))
           return
         }
-        
+
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = jsonKeyDecodingStrategy
         decoder.dateDecodingStrategy = .iso8601
-        
+
         do {
           let result = try decoder.decode(D.self, from: data1)
           continuation.resume(with: .success((result, response)))
@@ -69,24 +69,24 @@ struct NetworkClient {
           continuation.resume(with: .failure(error))
         }
       }
-      
+
       task.resume()
     }
   }
-  
+
   private func buildModifyingRequest<E: Encodable>(url: URL, method: String, headers: Dictionary<String, String>?, contentType: HttpRequestContentType = .json ,body: E?) -> URLRequest {
     let bodyData: Data? = contentType == .json ? buildJsonBody(body: body) : body as? Data
     return createRequest(url: url, method: method, headers: headers, contentType: contentType, bodyData: bodyData)
   }
-  
+
   private func buildJsonBody<E: Encodable>(body: E?) -> Data? {
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .useDefaultKeys
     encoder.outputFormatting = .sortedKeys
-    
+
     return try? encoder.encode(body)
   }
-  
+
   private func isErrorStatusCode(_ response: HTTPURLResponse) -> Bool {
     return response.statusCode >= 400
   }
@@ -97,7 +97,7 @@ public func buildPostFormBodyFrom(dictionary: Dictionary<String, String>) -> Dat
   urlComponents.queryItems = dictionary.map {
     URLQueryItem(name: $0.key, value: $0.value)
   }
-  
+
   return urlComponents.query?.data(using: .utf8) ?? kBlankData
 }
 
@@ -110,7 +110,7 @@ fileprivate enum HttpMethod: String {
 
 enum HttpRequestContentType: String {
   case json, form
-  
+
   var mimeDescription: String {
     switch self {
     case .json:

--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -4,9 +4,9 @@ import Foundation
 
 struct NetworkRoutes {
   let environment: Environment
-  
+
   // MARK: - Calculated properties
-  
+
   var loginAuthURL: URL {
     switch environment {
     case .production:
@@ -15,7 +15,7 @@ struct NetworkRoutes {
       return URL(string: "http://localhost:\(kTestServerPort)/auth/api/v1/\(environment.regionCode)/public/login")!
     }
   }
-  
+
   var apiAuthURL: URL {
     switch environment {
     case .production:
@@ -24,7 +24,7 @@ struct NetworkRoutes {
       return URL(string: "http://localhost:\(kTestServerPort)/as/authorization.oauth2")!
     }
   }
-  
+
   var apiTokenURL: URL {
     switch environment {
     case .production:
@@ -33,7 +33,7 @@ struct NetworkRoutes {
       return URL(string: "http://localhost:\(kTestServerPort)/as/token.oauth2")!
     }
   }
-  
+
   var vehiclesURL: URL {
     switch environment {
     case .production:
@@ -42,9 +42,9 @@ struct NetworkRoutes {
       return URL(string: "http://localhost:\(kTestServerPort)/core/api/v3/\(environment.regionCode)/vehicles")!
     }
   }
-  
+
   // MARK: - Functions
-  
+
   func vehicleSummaryURL(vehicle: Vehicle) -> URL {
     switch environment {
     case .production:
@@ -53,7 +53,7 @@ struct NetworkRoutes {
       return URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/vehicle-summary/\(vehicle.vin)")!
     }
   }
-  
+
   func vehiclePositionURL(vehicle: Vehicle) -> URL {
     switch environment {
     case .production:
@@ -62,16 +62,16 @@ struct NetworkRoutes {
       return URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/car-finder/\(vehicle.vin)/position")!
     }
   }
-  
+
   func vehicleCapabilitiesURL(vehicle: Vehicle) -> URL {
-    switch environment { 
+    switch environment {
     case .production:
       return URL(string: "https://api.porsche.com/service-vehicle/vcs/capabilities/\(vehicle.vin)")!
     case .test:
       return URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/vcs/capabilities/\(vehicle.vin)")!
     }
   }
-  
+
   func vehicleEmobilityURL(vehicle: Vehicle, capabilities: Capabilities ) -> URL {
     switch environment {
     case .production:
@@ -80,7 +80,7 @@ struct NetworkRoutes {
       return URL(string: "http://localhost:\(kTestServerPort)/e-mobility/\(environment.regionCode)/\(capabilities.carModel)/\(vehicle.vin)?timezone=Europe/Dublin")!
     }
   }
-  
+
   func vehicleFlashURL(vehicle: Vehicle) -> URL {
     switch environment {
     case .production:
@@ -89,7 +89,7 @@ struct NetworkRoutes {
       return URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/honk-and-flash/\(vehicle.vin)/flash")!
     }
   }
-  
+
   func vehicleHonkAndFlashURL(vehicle: Vehicle) -> URL {
     switch environment {
     case .production:

--- a/Sources/PorscheConnect/PorscheConnect+Auth.swift
+++ b/Sources/PorscheConnect/PorscheConnect+Auth.swift
@@ -1,37 +1,37 @@
 import Foundation
 
 public extension PorscheConnect {
-  
+
   func auth(application: Application) async throws -> PorscheAuth {
     let loginToRetrieveCookiesResponse = try await loginToRetrieveCookies()
     guard loginToRetrieveCookiesResponse != nil else { throw PorscheConnectError.NoResult }
-  
+
     let apiAuthCodeResult = try await getApiAuthCode(application: application)
     guard let codeVerifier = apiAuthCodeResult.codeVerifier,
           let code = apiAuthCodeResult.code else { throw PorscheConnectError.NoResult }
-    
+
     let apiTokenResult = try await getApiToken(application: application, codeVerifier: codeVerifier, code: code)
     guard let porscheAuth = apiTokenResult.data,
           apiTokenResult.response != nil else { throw PorscheConnectError.NoResult }
-    
+
     auths[application] = porscheAuth
     return porscheAuth
   }
-  
+
   private func loginToRetrieveCookies() async throws -> HTTPURLResponse? {
     let loginBody = buildLoginBody(username: username, password: password)
     let result = try await networkClient.post(String.self, url: networkRoutes.loginAuthURL, body: buildPostFormBodyFrom(dictionary: loginBody), contentType: .form, parseResponseBody: false)
     if let response = result.response,
        let statusCode = HttpStatusCode(rawValue: response.statusCode),
        statusCode == .OK { AuthLogger.info("Login to retrieve cookies successful") }
-    
+
     return result.response
   }
-  
+
   private func getApiAuthCode(application: Application) async throws -> (code: String?, codeVerifier: String?, response: HTTPURLResponse?) {
     let codeVerifier = codeChallenger.generateCodeVerifier()! //TODO: handle null
     AuthLogger.debug("Code Verifier: \(codeVerifier)")
-    
+
     let apiAuthParams = buildApiAuthParams(clientId: application.clientId, redirectURL: application.redirectURL, codeVerifier: codeVerifier)
     let result = try await networkClient.get(String.self, url: networkRoutes.apiAuthURL, params: apiAuthParams, parseResponseBody: false)
     if let response = result.response, let url = response.value(forHTTPHeaderField: "cdn-original-uri"),
@@ -42,17 +42,17 @@ public extension PorscheConnect {
       throw PorscheConnectError.AuthFailure
     }
   }
-  
+
   private func getApiToken(application: Application, codeVerifier: String, code: String) async throws -> (data: PorscheAuth?, response: HTTPURLResponse?) {
     let apiTokenBody = buildApiTokenBody(clientId: application.clientId, redirectURL: application.redirectURL, code: code, codeVerifier: codeVerifier)
     let result = try await networkClient.post(PorscheAuth.self, url: networkRoutes.apiTokenURL, body: buildPostFormBodyFrom(dictionary: apiTokenBody), contentType: .form)
     if let response = result.response,
        let statusCode = HttpStatusCode(rawValue: response.statusCode),
        statusCode == .OK { AuthLogger.info("Api Auth call for token successful") }
-    
+
     return result
   }
-  
+
   private func buildLoginBody(username: String, password: String) -> Dictionary<String, String> {
     return ["username": username,
             "password": password,
@@ -62,11 +62,11 @@ public extension PorscheConnect {
             "thirdPartyId": "",
             "state": ""]
   }
-  
+
   private func buildApiAuthParams(clientId: String, redirectURL: URL, codeVerifier: String) -> Dictionary<String, String> {
     let codeChallenge = codeChallenger.codeChallenge(for: codeVerifier)! //TODO: Handle null
     AuthLogger.debug("Code Challenge: \(codeChallenge)")
-    
+
     return ["client_id": clientId,
             "redirect_uri": redirectURL.absoluteString,
             "code_challenge": codeChallenge,
@@ -76,7 +76,7 @@ public extension PorscheConnect {
             "prompt": "none",
             "code_challenge_method": "S256"]
   }
-  
+
   private func buildApiTokenBody(clientId: String, redirectURL: URL, code: String, codeVerifier: String) -> Dictionary<String, String> {
     return ["client_id": clientId,
             "redirect_uri": redirectURL.absoluteString,

--- a/Sources/PorscheConnect/PorscheConnect+CarControl.swift
+++ b/Sources/PorscheConnect/PorscheConnect+CarControl.swift
@@ -1,64 +1,64 @@
 import Foundation
 
 public extension PorscheConnect {
-  
+
   func summary(vehicle: Vehicle) async throws -> (summary: Summary?, response: HTTPURLResponse?) {
     let application: Application = .carControl
-    
-    _ = try await authIfRequired(application: application)
-    
-    guard let auth = auths[application], let apiKey = auth.apiKey else { throw PorscheConnectError.AuthFailure }
-    let headers = buildHeaders(accessToken: auth.accessToken, apiKey: apiKey, countryCode: environment.countryCode, languageCode: environment.languageCode)
-    
-    let result = try await networkClient.get(Summary.self, url: networkRoutes.vehicleSummaryURL(vehicle: vehicle), headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys)
-    return (summary: result.data, response: result.response)
-  }
-  
-  func position(vehicle: Vehicle) async throws -> (position: Position?, response: HTTPURLResponse?) {
-    let application: Application = .carControl
-    
-    _ = try await authIfRequired(application: application)
-    
-    guard let auth = auths[application], let apiKey = auth.apiKey else { throw PorscheConnectError.AuthFailure }
-    let headers = buildHeaders(accessToken: auth.accessToken, apiKey: apiKey, countryCode: environment.countryCode, languageCode: environment.languageCode)
-    
-    let result = try await networkClient.get(Position.self, url: networkRoutes.vehiclePositionURL(vehicle: vehicle), headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys)
-    return (position: result.data, response: result.response)
-  }
-  
-  func capabilities(vehicle: Vehicle) async throws -> (capabilities: Capabilities?, response: HTTPURLResponse?) {
-    let application: Application = .carControl
-    
+
     _ = try await authIfRequired(application: application)
 
     guard let auth = auths[application], let apiKey = auth.apiKey else { throw PorscheConnectError.AuthFailure }
     let headers = buildHeaders(accessToken: auth.accessToken, apiKey: apiKey, countryCode: environment.countryCode, languageCode: environment.languageCode)
-    
+
+    let result = try await networkClient.get(Summary.self, url: networkRoutes.vehicleSummaryURL(vehicle: vehicle), headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys)
+    return (summary: result.data, response: result.response)
+  }
+
+  func position(vehicle: Vehicle) async throws -> (position: Position?, response: HTTPURLResponse?) {
+    let application: Application = .carControl
+
+    _ = try await authIfRequired(application: application)
+
+    guard let auth = auths[application], let apiKey = auth.apiKey else { throw PorscheConnectError.AuthFailure }
+    let headers = buildHeaders(accessToken: auth.accessToken, apiKey: apiKey, countryCode: environment.countryCode, languageCode: environment.languageCode)
+
+    let result = try await networkClient.get(Position.self, url: networkRoutes.vehiclePositionURL(vehicle: vehicle), headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys)
+    return (position: result.data, response: result.response)
+  }
+
+  func capabilities(vehicle: Vehicle) async throws -> (capabilities: Capabilities?, response: HTTPURLResponse?) {
+    let application: Application = .carControl
+
+    _ = try await authIfRequired(application: application)
+
+    guard let auth = auths[application], let apiKey = auth.apiKey else { throw PorscheConnectError.AuthFailure }
+    let headers = buildHeaders(accessToken: auth.accessToken, apiKey: apiKey, countryCode: environment.countryCode, languageCode: environment.languageCode)
+
     let result = try await networkClient.get(Capabilities.self, url: networkRoutes.vehicleCapabilitiesURL(vehicle: vehicle), headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys)
     return (capabilities: result.data, response: result.response)
   }
-  
+
   func emobility(vehicle: Vehicle, capabilities: Capabilities) async throws -> (emobility: Emobility?, response: HTTPURLResponse?) {
     let application: Application = .carControl
-    
+
     _ = try await authIfRequired(application: application)
-    
+
     guard let auth = auths[application], let apiKey = auth.apiKey else { throw PorscheConnectError.AuthFailure }
     let headers = buildHeaders(accessToken: auth.accessToken, apiKey: apiKey, countryCode: environment.countryCode, languageCode: environment.languageCode)
 
     let result = try await networkClient.get(Emobility.self, url: networkRoutes.vehicleEmobilityURL(vehicle: vehicle, capabilities: capabilities), headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys)
     return (emobility: result.data, response: result.response)
   }
-  
+
   func flash(vehicle: Vehicle, andHonk honk: Bool = false) async throws -> (remoteCommandAccepted: RemoteCommandAccepted?, response: HTTPURLResponse?) {
     let application: Application = .carControl
-    
+
     _ = try await authIfRequired(application: application)
-    
+
     guard let auth = auths[application], let apiKey = auth.apiKey else { throw PorscheConnectError.AuthFailure }
     let headers = buildHeaders(accessToken: auth.accessToken, apiKey: apiKey, countryCode: environment.countryCode, languageCode: environment.languageCode)
     let url = honk ? networkRoutes.vehicleHonkAndFlashURL(vehicle: vehicle) : networkRoutes.vehicleFlashURL(vehicle: vehicle)
-    
+
     var result = try await networkClient.post(RemoteCommandAccepted.self, url: url, body: kBlankString, headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys)
     result.data?.remoteCommand = .honkAndFlash
     return (remoteCommandAccepted: result.data, response: result.response)

--- a/Sources/PorscheConnect/PorscheConnect+Portal.swift
+++ b/Sources/PorscheConnect/PorscheConnect+Portal.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 public extension PorscheConnect {
-  
+
   func vehicles() async throws -> (vehicles: [Vehicle]?, response: HTTPURLResponse?) {
     let application: Application = .api
-    
+
     _ = try await authIfRequired(application: application)
-    
+
     guard let auth = auths[application], let apiKey = auth.apiKey else { throw PorscheConnectError.AuthFailure }
     let headers = buildHeaders(accessToken: auth.accessToken, apiKey: apiKey, countryCode: environment.countryCode, languageCode: environment.languageCode)
-    
+
     let result = try await networkClient.get([Vehicle].self, url: networkRoutes.vehiclesURL, headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys)
     return (vehicles: result.data, response: result.response)
   }

--- a/Sources/PorscheConnect/PorscheConnect.swift
+++ b/Sources/PorscheConnect/PorscheConnect.swift
@@ -4,7 +4,7 @@ import Foundation
 
 public enum Environment: String {
   case production, test
-  
+
   public var countryCode: String {
     switch self {
     case .production:
@@ -13,7 +13,7 @@ public enum Environment: String {
       return "ie"
     }
   }
-  
+
   public var languageCode: String {
     switch self {
     case .production:
@@ -22,7 +22,7 @@ public enum Environment: String {
       return "en"
     }
   }
-  
+
   public var regionCode: String {
     switch self {
     case .production:
@@ -35,7 +35,7 @@ public enum Environment: String {
 
 public enum Application {
   case api, carControl
-  
+
   public var clientId: String {
     switch self {
     case .api:
@@ -44,7 +44,7 @@ public enum Application {
       return "Ux8WmyzsOAGGmvmWnW7GLEjIILHEztAs"
     }
   }
-  
+
   public var redirectURL: URL {
     switch self {
     case .api:
@@ -64,27 +64,27 @@ public enum PorscheConnectError: Error {
 // MARK: - Porsche Connect
 
 public class PorscheConnect {
-  
+
   let environment: Environment
   let username: String
   var auths: Dictionary<Application, PorscheAuth> = Dictionary()
-  
+
   let networkClient = NetworkClient()
   let networkRoutes: NetworkRoutes
   let password: String
   let codeChallenger = CodeChallenger()
-  
+
   // MARK: - Init & configuration
-  
+
   public init(username: String, password: String, environment: Environment = .production) {
     self.username = username
     self.password = password
     self.environment = environment
     self.networkRoutes = NetworkRoutes(environment: environment)
   }
-  
+
   // MARK: - Common functions
-  
+
   func authorized(application: Application) -> Bool {
     guard let auth = auths[application] else {
       return false
@@ -92,18 +92,18 @@ public class PorscheConnect {
 
     return !auth.expired
   }
-  
+
   func buildHeaders(accessToken: String, apiKey: String, countryCode: String, languageCode: String) -> Dictionary<String, String> {
     return ["Authorization": "Bearer \(accessToken)",
             "apikey": apiKey,
             "x-vrs-url-country": countryCode,
             "x-vrs-url-language": "\(languageCode)_\(countryCode.uppercased())"]
   }
-  
+
   func authIfRequired(application: Application) async throws {
     if !authorized(application: application) {
       do {
-      _ = try await auth(application: application)
+        _ = try await auth(application: application)
       } catch {
         throw PorscheConnectError.AuthFailure
       }

--- a/Tests/PorscheConnectTests/CodeChallengerTests.swift
+++ b/Tests/PorscheConnectTests/CodeChallengerTests.swift
@@ -2,26 +2,26 @@ import XCTest
 @testable import PorscheConnect
 
 final class CodeChallengerTests: XCTestCase {
-    
+
   func testGenerateCodeVerifier() {
     let codeChallenger = CodeChallenger(length: 64)
     XCTAssertNotNil(codeChallenger)
-    
+
     let codeVerifier = codeChallenger.generateCodeVerifier()!
     XCTAssertNotNil(codeVerifier)
   }
-  
+
   func testCodeChallengeFromGeneratedCodeVerifier() {
     let codeChallenger = CodeChallenger(length: 64)
     XCTAssertNotNil(codeChallenger)
-    
+
     let codeVerifier = codeChallenger.generateCodeVerifier()!
     XCTAssertNotNil(codeVerifier)
-    
+
     let codeChallenge = codeChallenger.codeChallenge(for: codeVerifier)!
     XCTAssertNotNil(codeChallenge)
   }
-  
+
   func testCodeChallenge() {
     let codeChallenger = CodeChallenger(length: 64)
     XCTAssertNotNil(codeChallenger)
@@ -29,7 +29,7 @@ final class CodeChallengerTests: XCTestCase {
     XCTAssertEqual("dADBvw4mcionJ5slawFhCxPFdHKdZ5naQri71Dq8OxA", codeChallenger.codeChallenge(for: "R9TKdFZFg6vSg1fBA1sckttPmbVEiPLoNjDZIGFozC8FETVzayig")!)
     XCTAssertEqual("Tsnu08fmm7D9XIx_XZnfub_QX0qDoQno4q7eRj7dHgw", codeChallenger.codeChallenge(for: "QtT30VN5sy2HjI8nooey8qLPuuRuOg32KJEg2bRpSVe6DFEPe6lDw")!)
   }
-  
+
   func testCodeChallengeTwice() {
     let codeChallenger = CodeChallenger(length: 64)
     XCTAssertNotNil(codeChallenger)

--- a/Tests/PorscheConnectTests/Common/BaseMockNetworkTestCase.swift
+++ b/Tests/PorscheConnectTests/Common/BaseMockNetworkTestCase.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import PorscheConnect
 
 class BaseMockNetworkTestCase: XCTestCase {
-      
+
   // MARK: - Lifecycle
 
   override func setUp() {

--- a/Tests/PorscheConnectTests/Common/MockNetworkRoutes.swift
+++ b/Tests/PorscheConnectTests/Common/MockNetworkRoutes.swift
@@ -2,9 +2,9 @@ import Foundation
 import Ambassador
 
 final class MockNetworkRoutes {
-  
+
   // MARK: - Properties
-  
+
   private static let getHelloWorldPath = "/hello_world.json"
   private static let getApiAuthPath = "/as/authorization.oauth2"
   private static let getVehiclesPath = "/core/api/v3/ie/en_IE/vehicles"
@@ -20,145 +20,145 @@ final class MockNetworkRoutes {
   private static let postHonkAndFlashPath = "/service-vehicle/honk-and-flash/A1234/honk-and-flash"
 
   // MARK: - Hello World
-  
+
   func mockGetHelloWorldSuccessful(router: Router) {
     router[MockNetworkRoutes.getHelloWorldPath] = JSONResponse(statusCode: 200) { (req) -> Any in
       return self.mockHelloWorldResponse()
     }
   }
-  
+
   func mockGetHelloWorldFailure(router: Router) {
     router[MockNetworkRoutes.getHelloWorldPath] = JSONResponse(statusCode: 401, statusMessage: "unauthorized")
   }
-  
+
   // MARK: - Post Login Auth
-  
+
   func mockPostLoginAuthSuccessful(router: Router) {
     router[MockNetworkRoutes.postLoginAuthPath] = DataResponse(statusCode: 200, statusMessage: "ok", headers: [("Set-Cookie", "CIAM.status=mockValue")])
   }
-  
+
   func mockPostLoginAuthFailure(router: Router) {
     router[MockNetworkRoutes.postLoginAuthPath] = DataResponse(statusCode: 400, statusMessage: "bad request")
   }
-  
+
   // MARK: - Get Api Auth
-  
+
   func mockGetApiAuthSuccessful(router: Router) {
     router[MockNetworkRoutes.getApiAuthPath] = DataResponse(statusCode: 200, statusMessage: "ok", headers: [("cdn-original-uri", "/static/cms/auth.html?code=fqFQlQSUfNkMGtMLj0zRK0RriKdPySGVMmVXPAAC")])
   }
-  
+
   func mockGetApiAuthFailure(router: Router) {
     router[MockNetworkRoutes.getApiAuthPath] = DataResponse(statusCode: 400, statusMessage: "bad request")
   }
-  
+
   // MARK: - Post Api Token
-  
+
   func mockPostApiTokenSuccessful(router: Router) {
     router[MockNetworkRoutes.postApiTokenPath] = JSONResponse(statusCode: 200) { (req) -> Any in
       return self.mockApiTokenResponse()
     }
   }
-  
+
   func mockPostApiTokenFailure(router: Router) {
     router[MockNetworkRoutes.postApiTokenPath] = DataResponse(statusCode: 400, statusMessage: "bad request")
   }
-  
+
   // MARK: - Get Vehicles
-  
+
   func mockGetVehiclesSuccessful(router: Router) {
     router[MockNetworkRoutes.getVehiclesPath] = JSONResponse(statusCode: 200) { (req) -> Any in
       return self.mockVehiclesResponse()
     }
   }
-  
+
   func mockGetVehiclesFailure(router: Router) {
     router[MockNetworkRoutes.getVehiclesPath] = DataResponse(statusCode: 400, statusMessage: "bad request")
   }
-  
+
   // MARK: - Get Summary
-  
+
   func mockGetSummarySuccessful(router: Router) {
     router[MockNetworkRoutes.getSummaryPath] = JSONResponse(statusCode: 200) { (req) -> Any in
       return self.mockSummaryResponse()
     }
   }
-  
+
   func mockGetSummaryFailure(router: Router) {
     router[MockNetworkRoutes.getSummaryPath] = DataResponse(statusCode: 400, statusMessage: "bad request")
   }
-  
+
   // MARK: - Get Position
-  
+
   func mockGetPositionSuccessful(router: Router) {
     router[MockNetworkRoutes.getPositionPath] = JSONResponse(statusCode: 200) { (req) -> Any in
       return self.mockPositionResponse()
     }
   }
-  
+
   func mockGetPositionFailure(router: Router) {
     router[MockNetworkRoutes.getPositionPath] = DataResponse(statusCode: 400, statusMessage: "bad request")
   }
-  
+
   // MARK: - Get Capabilities
-  
+
   func mockGetCapabilitiesSuccessful(router: Router) {
     router[MockNetworkRoutes.getCapabilitiesPath] = JSONResponse(statusCode: 200) { (req) -> Any in
       return self.mockCapabilitiesResponse()
     }
   }
-  
+
   func mockGetCapabilitiesFailure(router: Router) {
     router[MockNetworkRoutes.getCapabilitiesPath] = DataResponse(statusCode: 400, statusMessage: "bad request")
   }
-  
+
   // MARK: - Get Emobility
-  
+
   func mockGetEmobilityNotChargingSuccessful(router: Router) {
     router[MockNetworkRoutes.getEmobilityPath] = JSONResponse(statusCode: 200) { (req) -> Any in
       return self.mockEmobilityResponse(mockedResponse: kEmobilityNotChargingJson)
     }
   }
-  
+
   func mockGetEmobilityACTimerChargingSuccessful(router: Router) {
     router[MockNetworkRoutes.getEmobilityPath] = JSONResponse(statusCode: 200) { (req) -> Any in
       return self.mockEmobilityResponse(mockedResponse: kEmobilityACTimerChargingJson)
     }
   }
-  
+
   func mockGetEmobilityACDirectChargingSuccessful(router: Router) {
     router[MockNetworkRoutes.getEmobilityPath] = JSONResponse(statusCode: 200) { (req) -> Any in
       return self.mockEmobilityResponse(mockedResponse: kEmobilityACDirectChargingJson)
     }
   }
-  
+
   func mockGetEmobilityDCChargingSuccessful(router: Router) {
     router[MockNetworkRoutes.getEmobilityPath] = JSONResponse(statusCode: 200) { (req) -> Any in
       return self.mockEmobilityResponse(mockedResponse: kEmobilityDCChargingJson)
     }
   }
-  
+
   func mockGetEmobilityFailure(router: Router) {
     router[MockNetworkRoutes.getEmobilityPath] = DataResponse(statusCode: 400, statusMessage: "bad request")
   }
-  
+
   // MARK: – Get Honk and Flash
-  
+
   func mockPostFlashSuccessful(router: Router) {
     router[MockNetworkRoutes.postFlashPath] = JSONResponse(statusCode: 200, handler: { (req) -> Any in
       return self.mockRemoteCommandAccepted()
     })
   }
-  
+
   func mockPostFlashFailure(router: Router) {
     router[MockNetworkRoutes.postFlashPath] = DataResponse(statusCode: 400, statusMessage: "bad request")
   }
-  
+
   func mockPostHonkAndFlashSuccessful(router: Router) {
     router[MockNetworkRoutes.postHonkAndFlashPath] = JSONResponse(statusCode: 200, handler: { (req) -> Any in
       return self.mockRemoteCommandAccepted()
     })
   }
-  
+
   func mockPostHonkAndFlashFailure(router: Router) {
     router[MockNetworkRoutes.postHonkAndFlashPath] = DataResponse(statusCode: 400, statusMessage: "bad request")
   }
@@ -176,20 +176,20 @@ final class MockNetworkRoutes {
       return self.mockRemoteCommandStatusSuccess()
     })
   }
-  
+
   // MARK: - Mock Responses
-  
+
   private func mockHelloWorldResponse() -> Dictionary<String, Any> {
     return ["message": "Hello World!"]
   }
-  
+
   private func mockApiTokenResponse() -> Dictionary<String, Any> {
     return ["access_token": "Kpjg2m1ZXd8GM0pvNIB3jogWd0o6",
             "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE1bF9LeldTV08tQ1ZNdXdlTmQyMnMifQ.eyJzdWIiOiI4N3VnOGJobXZydnF5bTFrIiwiYXVkIjoiVFo0VmY1d25LZWlwSnh2YXRKNjBsUEhZRXpxWjRXTnAiLCJqdGkiOiJmTldhWEE4RTBXUzNmVzVZU0VmNFRDIiwiaXNzIjoiaHR0cHM6XC9cL2xvZ2luLnBvcnNjaGUuY29tIiwiaWF0IjoxNjEyNzQxNDA4LCJleHAiOjE2MTI3NDE3MDgsInBpLnNyaSI6InNoeTN3aDN4RFVWSFlwd0pPYmpQdHJ5Y2FpOCJ9.EsgxbnDCdEC0O8b05B_VJoe09etxcQOqhj4bRkR-AOwZrFV0Ba5LGkUFD_8GxksWuCn9W_bG_vHNOxpcum-avI7r2qY3N2iMJHZaOc0Y-NqBPCu5kUN3F5oh8e7aDbBKQI_ZWTxRdMvcTC8zKJRZf0Ud2YFQSk6caGwmqJ5OE_OB38_ovbAiVRgV_beHePWpEkdADKKtlF5bmSViHOoUOs8x6j21mCXDiuMPf62oRxU4yPN-AS4wICtz22dabFgdjIwOAFm651098z2zwEUEAPAGkcRKuvSHlZ8OAvi4IXSFPXBdCfcfXRk5KdCXxP1xaZW0ItbrQZORdI12hVFoUQ",
             "token_type": "Bearer",
             "expires_in":7199]
   }
-  
+
   private func mockVehiclesResponse() -> [Dictionary<String, Any>] {
     return [
       ["vin": "VIN12345",
@@ -201,12 +201,12 @@ final class MockNetworkRoutes {
       ]
     ]
   }
-  
+
   private func mockSummaryResponse() -> Dictionary<String, Any> {
     return ["modelDescription": "Taycan 4S",
             "nickName": "211-D-12345"]
   }
-  
+
   private func mockPositionResponse() -> Dictionary<String, Any> {
     return ["carCoordinate":
               ["geoCoordinateSystem": "WGS84",
@@ -214,7 +214,7 @@ final class MockNetworkRoutes {
                "longitude": -6.389296],
             "heading": 68]
   }
-  
+
   private func mockCapabilitiesResponse() -> Dictionary<String, Any> {
     return ["displayParkingBrake": true,
             "needsSPIN": true,
@@ -232,11 +232,11 @@ final class MockNetworkRoutes {
             "steeringWheelPosition": "RIGHT",
             "hasHonkAndFlash": true]
   }
-  
+
   private func mockEmobilityResponse(mockedResponse: Data) -> Dictionary<String, Any> {
     return try! (JSONSerialization.jsonObject(with: mockedResponse, options: []) as! Dictionary<String, Any>)
   }
-  
+
   private func mockRemoteCommandAccepted() -> Dictionary<String, Any> {
     return ["id": "123456789", "lastUpdated": "2022-12-27T13:19:23Z"]
   }

--- a/Tests/PorscheConnectTests/Common/MockServer.swift
+++ b/Tests/PorscheConnectTests/Common/MockServer.swift
@@ -9,31 +9,31 @@ class MockServer {
   let router = Router()
   let loop = try! SelectorEventLoop(selector: try! KqueueSelector())
   var server: DefaultHTTPServer!
-  
+
   private init() {
     setupMockWebServer()
   }
-  
+
   // MARK: - Private
-  
+
   private func setupMockWebServer() {
     server = DefaultHTTPServer(eventLoop: loop, port: kTestServerPort, app: router.app)
-    
+
     try! server.start()
-    
+
     print("Mock Web Server at port \(server.port): starting")
-    
+
     DispatchQueue.global().async {
       self.loop.runForever()
     }
-    
+
     waitForServer()
   }
-  
+
   private func waitForServer() {
     let semaphore = DispatchSemaphore(value: 0)
     let connection = NWConnection(host: "localhost", port: NWEndpoint.Port(rawValue: NWEndpoint.Port.RawValue(server.port))!, using: .tcp)
-    
+
     connection.start(queue: .init(label: "Socket Q"))
     connection.stateUpdateHandler = { (newState) in
       switch (newState) {
@@ -43,7 +43,7 @@ class MockServer {
         break
       }
     }
-    
+
     semaphore.wait()
     print("Mock Web Server at port \(server.port): started")
   }

--- a/Tests/PorscheConnectTests/Common/TestConstants.swift
+++ b/Tests/PorscheConnectTests/Common/TestConstants.swift
@@ -9,9 +9,9 @@ let kTestServerPort = 8080
 // MARK: - Test Objects & Value Types
 
 let kTestPorschePortalAuth =  PorscheAuth(accessToken: "zVb3smCN32iOslsoXa7XIYPrenGz",
-                                    idToken: "yJhbGciOiJSUzI1NiIsImtpZCI6IjE1bF9LeldTV08tQ1ZNdXdlTmQyMnMifQ.eyJzdWIiOiI4N3VnOGJobXZydnF5bTFrIiwiYXVkIjoiVFo0VmY1d25LZWlwSnh2YXRKNjBsUEhZRXpxWjRXTnAiLCJqdGkiOiI5NWhPT0ZlSDdzZW9yaVZ2bUNhTWdWIiwiaXNzIjoiaHR0cHM6XC9cL2xvZ2luLnBvcnNjaGUuY29tIiwiaWF0IjoxNjEyNzQwOTE2LCJleHAiOjE2MTI3NDEyMTYsInBpLnNyaSI6IkVYYjZSSlFpRWZLazNRZWk0Y1dyTWlwSmgxSSJ9.bVzapayesKjA85pRwVBZN_TfKzPNFTOb6nszPSWElMU2-MOzmJjy6dWHTjN3jCCx3Ui20XDwHkkDOdIUZqIQq6nve5ihbRlNi1ywrNiKKLOL7nmfzmM7yBPMZfwxtCP_-imypF_n19i1rZDkatIkW0Ejs7lcc0xRD9JewGMhfALqpFuOciIX3SIInHE56WSmTNyEB1LTNNLXiwaBWygPVbYDAYYc4u-w3V_GPZR3kTSTJjwnfXM9Qke6wBcoXDaON4_NfNcTQf0vXYwhC749dJd8Z2eDcRTl-Yl06BTHHTIL-yInfk8yjCO1iaCv01ROjK_nGAyPsOvUKtVgsaXxnw",
-                                    tokenType: "Bearer",
-                                    expiresIn: 7199)
+                                          idToken: "yJhbGciOiJSUzI1NiIsImtpZCI6IjE1bF9LeldTV08tQ1ZNdXdlTmQyMnMifQ.eyJzdWIiOiI4N3VnOGJobXZydnF5bTFrIiwiYXVkIjoiVFo0VmY1d25LZWlwSnh2YXRKNjBsUEhZRXpxWjRXTnAiLCJqdGkiOiI5NWhPT0ZlSDdzZW9yaVZ2bUNhTWdWIiwiaXNzIjoiaHR0cHM6XC9cL2xvZ2luLnBvcnNjaGUuY29tIiwiaWF0IjoxNjEyNzQwOTE2LCJleHAiOjE2MTI3NDEyMTYsInBpLnNyaSI6IkVYYjZSSlFpRWZLazNRZWk0Y1dyTWlwSmgxSSJ9.bVzapayesKjA85pRwVBZN_TfKzPNFTOb6nszPSWElMU2-MOzmJjy6dWHTjN3jCCx3Ui20XDwHkkDOdIUZqIQq6nve5ihbRlNi1ywrNiKKLOL7nmfzmM7yBPMZfwxtCP_-imypF_n19i1rZDkatIkW0Ejs7lcc0xRD9JewGMhfALqpFuOciIX3SIInHE56WSmTNyEB1LTNNLXiwaBWygPVbYDAYYc4u-w3V_GPZR3kTSTJjwnfXM9Qke6wBcoXDaON4_NfNcTQf0vXYwhC749dJd8Z2eDcRTl-Yl06BTHHTIL-yInfk8yjCO1iaCv01ROjK_nGAyPsOvUKtVgsaXxnw",
+                                          tokenType: "Bearer",
+                                          expiresIn: 7199)
 
 
 
@@ -22,6 +22,5 @@ func buildCapabilites() -> Capabilities {
   let json = "{\"displayParkingBrake\": true, \"needsSPIN\": true, \"hasRDK\": true, \"engineType\": \"BEV\", \"carModel\": \"J1\", \"onlineRemoteUpdateStatus\": {\"editableByUser\": true, \"active\": true }, \"heatingCapabilities\": {\"frontSeatHeatingAvailable\": true, \"rearSeatHeatingAvailable\": false}, \"steeringWheelPosition\": \"RIGHT\", \"hasHonkAndFlash\": true }".data(using: .utf8)!
   let decoder = JSONDecoder()
   decoder.keyDecodingStrategy = .useDefaultKeys
-   return try! decoder.decode(Capabilities.self, from: json)
+  return try! decoder.decode(Capabilities.self, from: json)
 }
-

--- a/Tests/PorscheConnectTests/ModelsTests.swift
+++ b/Tests/PorscheConnectTests/ModelsTests.swift
@@ -3,11 +3,11 @@ import SwiftUI
 @testable import PorscheConnect
 
 final class ModelsTests: XCTestCase {
-  
+
   let porscheAuth = kTestPorschePortalAuth
 
   // MARK: - Auth tests
-  
+
   func testPorscheAuthConstruction() {
     XCTAssertNotNil(porscheAuth)
     XCTAssertNotNil(porscheAuth.apiKey)
@@ -15,13 +15,13 @@ final class ModelsTests: XCTestCase {
     XCTAssertNotNil(porscheAuth.expiresAt)
     XCTAssertFalse(porscheAuth.expired)
   }
-  
+
   func testPorscheAuthDecodingJsonIntoModel() {
     let json =  "{\"access_token\":\"Kpjg2m1ZXd8GM0pvNIB3jogWd0o6\",\"id_token\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6IjE1bF9LeldTV08tQ1ZNdXdlTmQyMnMifQ.eyJzdWIiOiI4N3VnOGJobXZydnF5bTFrIiwiYXVkIjoiVFo0VmY1d25LZWlwSnh2YXRKNjBsUEhZRXpxWjRXTnAiLCJqdGkiOiJmTldhWEE4RTBXUzNmVzVZU0VmNFRDIiwiaXNzIjoiaHR0cHM6XC9cL2xvZ2luLnBvcnNjaGUuY29tIiwiaWF0IjoxNjEyNzQxNDA4LCJleHAiOjE2MTI3NDE3MDgsInBpLnNyaSI6InNoeTN3aDN4RFVWSFlwd0pPYmpQdHJ5Y2FpOCJ9.EsgxbnDCdEC0O8b05B_VJoe09etxcQOqhj4bRkR-AOwZrFV0Ba5LGkUFD_8GxksWuCn9W_bG_vHNOxpcum-avI7r2qY3N2iMJHZaOc0Y-NqBPCu5kUN3F5oh8e7aDbBKQI_ZWTxRdMvcTC8zKJRZf0Ud2YFQSk6caGwmqJ5OE_OB38_ovbAiVRgV_beHePWpEkdADKKtlF5bmSViHOoUOs8x6j21mCXDiuMPf62oRxU4yPN-AS4wICtz22dabFgdjIwOAFm651098z2zwEUEAPAGkcRKuvSHlZ8OAvi4IXSFPXBdCfcfXRk5KdCXxP1xaZW0ItbrQZORdI12hVFoUQ\",\"token_type\":\"Bearer\",\"expires_in\":7199}\r\n".data(using: .utf8)!
-    
+
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
-    
+
     let decodedPorscheAuth = try! decoder.decode(PorscheAuth.self, from: json)
     XCTAssertNotNil(decodedPorscheAuth)
     XCTAssertEqual("Kpjg2m1ZXd8GM0pvNIB3jogWd0o6", decodedPorscheAuth.accessToken)
@@ -33,14 +33,14 @@ final class ModelsTests: XCTestCase {
     XCTAssertNotNil(porscheAuth.expiresAt)
     XCTAssertFalse(porscheAuth.expired)
   }
-  
+
   func testDecodedJwtToken() {
     XCTAssertNotNil(porscheAuth)
     XCTAssertEqual("TZ4Vf5wnKeipJxvatJ60lPHYEzqZ4WNp", porscheAuth.apiKey)
   }
-  
+
   // MARK: - Vehicle tests
-  
+
   func testVehicleConstructionVariantOne() {
     let vehicle = Vehicle(vin: "WP0ZZZY4MSA38703",
                           modelDescription: "Taycan 4S",
@@ -50,7 +50,7 @@ final class ModelsTests: XCTestCase {
                           exteriorColorHex: "#47402e",
                           attributes: nil,
                           pictures: nil)
-    
+
     XCTAssertNotNil(vehicle)
     XCTAssertEqual("neptunblau/neptunblau", vehicle.exteriorColor)
     XCTAssertEqual("#47402e", vehicle.exteriorColorHex)
@@ -58,13 +58,13 @@ final class ModelsTests: XCTestCase {
     XCTAssertNil(vehicle.attributes)
     XCTAssertNil(vehicle.pictures)
   }
-  
+
   func testVehicleConstructionVariantTwo() {
     let vehicle = Vehicle(vin: "VIN12345",
                           modelDescription: "Taycan 4S",
                           modelType: "Y1ADB1",
                           modelYear: "2021")
-    
+
     XCTAssertEqual("VIN12345", vehicle.vin)
     XCTAssertEqual("Taycan 4S", vehicle.modelDescription)
     XCTAssertEqual("Y1ADB1", vehicle.modelType)
@@ -74,10 +74,10 @@ final class ModelsTests: XCTestCase {
     XCTAssertNil(vehicle.attributes)
     XCTAssertNil(vehicle.pictures)
   }
-  
+
   func testVehicleConstructionVariantThree() {
     let vehicle = Vehicle(vin: "VIN12345")
-    
+
     XCTAssertEqual("VIN12345", vehicle.vin)
     XCTAssertEqual(kBlankString, vehicle.modelDescription)
     XCTAssertEqual(kBlankString, vehicle.modelType)
@@ -87,37 +87,37 @@ final class ModelsTests: XCTestCase {
     XCTAssertNil(vehicle.attributes)
     XCTAssertNil(vehicle.pictures)
   }
-  
+
   func testVehicleDecodingJsonIntoModel() {
     let json = "[ {\n  \"vin\" : \"VIN12345\",\n  \"isPcc\" : true,\n  \"relationship\" : \"OWNER\",\n  \"maxSecondaryUsers\" : 5,\n  \"modelDescription\" : \"Taycan 4S\",\n  \"modelType\" : \"Y1ADB1\",\n  \"modelYear\" : \"2021\",\n  \"exteriorColor\" : \"neptunblau/neptunblau\",\n  \"exteriorColorHex\" : \"#47402e\",\n  \"spinEnabled\" : true,\n  \"loginMethod\" : \"PORSCHE_ID\",\n  \"pictures\" : [ {\n    \"url\" : \"https://picserv.porsche.com/picserv/images-api/v1/ec2bed3b73260c6f0116e12f538b1ac6/5\",\n    \"view\" : \"extcam01\",\n    \"size\" : 5,\n    \"width\" : 1920,\n    \"height\" : 1080,\n    \"transparent\" : true,\n    \"placeholder\" : null\n  }, {\n    \"url\" : \"https://picserv.porsche.com/picserv/images-api/v1/c11fb8a8bb320523ce6591d52c68f5cf/4\",\n    \"view\" : \"extcam01\",\n    \"size\" : 4,\n    \"width\" : 1440,\n    \"height\" : 810,\n    \"transparent\" : false,\n    \"placeholder\" : null\n  }, {\n    \"url\" : \"https://picserv.porsche.com/picserv/images-api/v1/c11fb8a8bb320523ce6591d52c68f5cf/3\",\n    \"view\" : \"extcam01\",\n    \"size\" : 3,\n    \"width\" : 960,\n    \"height\" : 540,\n    \"transparent\" : false,\n    \"placeholder\" : null\n  }, {\n    \"url\" : \"https://picserv.porsche.com/picserv/images-api/v1/ec2bed3b73260c6f0116e12f538b1ac6/2\",\n    \"view\" : \"extcam01\",\n    \"size\" : 2,\n    \"width\" : 640,\n    \"height\" : 360,\n    \"transparent\" : true,\n    \"placeholder\" : null\n  }, {\n    \"url\" : \"https://picserv.porsche.com/picserv/images-api/v1/ec2bed3b73260c6f0116e12f538b1ac6/1\",\n    \"view\" : \"extcam01\",\n    \"size\" : 1,\n    \"width\" : 128,\n    \"height\" : 72,\n    \"transparent\" : true,\n    \"placeholder\" : \"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABICAYAAAA+hf0SAAAo6UlEQVR42u18B3hU15m2CzaYKqqQUO8azUij0WjURr333nsHgRoSoI4kuui9iF5FB2GaC8UQ49527WycP9lks71kN8naCTbm3e87cy8ZaxEGJ7v430fned7n3rlz63nfr51zZ555ZqSNtJE20kbaSBtpI22kjbSRNtJG2kgbaSNtpI20kTbSRtpIG2kjbaSNtJE20kbaSBtpI22kjbSRNtL+TzVXbdhzTpqw8Y7e0RZOPvFqZ7+kUGf/lFTngLRSF31GnUtgZqtrUFavIji7zy0kd6NbaN52ZVj+XlV4wTFVWP5FWn9VGZZ3RRmaN+genjfgEZ7X7x6Wu1YRnNXuHpZTuXT9npSuVTuSE/PnOo309lNqjpqwUU66WIVXRE5aTtWi1nktK/Yu7Fl3o335pl/09G39ctWm3Xc37Tr01Y59x+7uPXzi7oGjp746dOzU3cMDJ+8eO37q7vETp+4eGzjxNS3vnTl7/t7pM+e+OnLs+N3+Pfv/sHnbrrtbCNt27ibs+XpH/3707zuCPQdPoP/Iy99cuv4+Lr7+Nq7d/gAvv3L706OnLs3xjcgYPcLK/2Ara143Ka2otmTFuh0Hz1y4+u7FV65/8da7H3z12WefffPhhx/izTffxLVr13D16lVcvnwZ58+fx6mTJ3H06FHs3r0b27dvx9atW7Fu3TqsWL4CvT29WLlipcDSJUuxuGsx2lvbsHDBQjQ1zkd9XT3mzZ2H2dWzUVlRifKycpSXl6OsvAKL1x7AwZOvYP/R01i9fis2bO3HwYHzn+/cfyJ8hKk/c9PH5pp4+wf3LVjU9lsm+fPPP8d7776HG9dv4NLFizh98hQOHzyE3bv6sXXzFqxbYyB41apVWLt2LTo6OrBw4UIsWLAAjY2NqKqqQnlpGaoqq1BBpBYXFSM/Lx/ZWdlIT0tHSnIKEhMSER8Xj7iYWMRExyA6KlogLTkVCfEJmNe2Dv2HzmHPnj3YsH6DuE5bWxs6Fi/5pnflxlWRyYWjRpj7MzRtQER6ekb2P545fQYfvPc+rr1+DefPnsfRw+SO+3dj66YtWNO3GsuXLkO3ZMELmhYIK165ciXmzZsnyGerZ5Kqq6uRmZ6BzIwMpDLRRGZsTAwiIyIRFhqG4KBgBAboEeDnDz9fP/j6+MJH5/MAMeFR8Kfv5nZswfY9xzAwMED3cw6XXr6IK1eu4PTp09i+Ywfqm9uuVNS2jh9h8Hu2qKyalwKCI3e2LmrFG9dv4ua1G7hwfhBHDx3BkUNHfnf+3LmfDZ4//xcb1q3/dUdbO1oWLCK33YRadtlV1cKyK8hVFxUWEoqQmZmJlBQD4fGxcYiKjHpAuJ4IZ7KZYG+tN7ReWnhpvKDx1MBT7WkENUICgqBy90B9z27h9g8fOoxBui++v9tv3MKNGzfw8ccf486dO1jQ0vFWVW2LyQibT9gCIlPtomISPti1fSdu37iF1668grOnzuDYkaNf3L51+32K+Zc++uijl6mTL/R29/yOyZ9f34ia6jlM/hcUr/89OzMbGeTO01PTBJh4duHhTHpgEAL8A+ArEW4g20Cw2kMNDyLYQ+UOdwEV3JUqIZDExESEBYVCqfZG8/L9qJnXSPu6I0gfiNKiEnR1dGLnzp1477338OEHH+DTTz9Fd+/Sm9X1bWNGWH3M5hMcG5aenv2vTPjt67fwysUrOH7kGC4MXvglEX/lk08+ufDuu++ev3379tnNmzd/uqiZEjYif251DQpy8zkM3Nm/f/+R9rb2GwX5+V/Onj1buP3KykqUlpYiJDgEOm+dIN2TyFYz2YJwiXQiW+XGUELp5gY3hRsUrgrk5uaioqICvt4+0PhHYNHKAygi0lVK1X0WjZ/OF4H+enFuDw8P+q4I+/btA90zWlrbj44w+xhNFxhZVVZa8dWrl1/Bretv4NLgRRw5ePje9WvXPyJrevmDDz44T1Z/ltzs6ZMnT15pqGu4N7+uEXMqq1GcX4TC3IL/3LFjxyHK9A9s2LBhP8X/f2QBcObOYFIiIiIE8WzdSoWBYBLAb0gQv6IQ8FPyDD+h8PAaWfvp8PDwq1FRURfj4+PP5uXlfVlYUABHe0dQuYe2lXvpfMVfJyQkvBETE3MnKDDkH8qq6tHcthRzG1uRU1CGyKhYyi9ihVeomTuvboThYVra3L5nffQRffPr5+Pm69cFBs+cx+EDh37/1p23bpHVD77zzjtnb926dfq11147efHixeOU0f99/dw6zK6oRm5WjsjW6+bV3ulq7xwsySv6rG5e3VUi/ZdMen5+vgDnAQmU3bOVM/nuSnLfAYGf52Rln8xKyfhFckzC3ZT4pN9mJqXfzc/M/VlWRtbJnJyc/uzs7D107NexsbEwMTFBZGYNOlftJK+Qh9TUtI/j4hM/q27f8rvFWwaxaN1pzF81gPrlR9C44gial/YjJj6VhBf5B09PjWqEbWru4Xl26oS5a0pbtn5U173jss4/5FhneyfeuHYT1155HWdOnMahA4d++/Zbb9+4dfv21bODF6/tOTjwxrpte97s6dv8bmP78s+yiuYgu2guMgrmICGjBHFpRSirbf8sKavsXnJWOVJzq75My6++m55fhbT8StqvCum0zKRlUmYx4lPzkJCSi/jkLMQnZtx3VWmh0Pjf9QqM+6l3aPJf+gYnfBEWmfK1PiT6bR9f//fcKdZPnToVkyZNQtacXnQt3ySSShIHotKKEVfSjrjCZgQmV8E7uhCaiFx4hGbAMzQTbj7hUFN+4ebm9hGViS/+nyY3Jbv0xajkApOwhLzJqbmVk4qrGr81OuYZXVylSa6/G1OzHvkNq+EdkoSM3FIs6lqF2Y1dSCuqR1BSKXSxRV+rwvPuuQbnwCUom5BlQGDmEGQ8gLM+HS76NAHngCGQt/mnwE2fCmVIFjyjSxCZ14TS5tVo69uHdbvPYu+JV3Fs8A2B3QNXsWX/eazfeRxt3X0IjU6Gua0CWTXL0NTag7S0NFRWVYFChUgQg4OD4efnB61WK/IAFxcX2NjYCPJ5Oy+XrljT83+C6MSM4md1EVkaj7CcJlV4/oAqsvhj9+iyf3ePqbjvkzQH3omzoYmrhEdUCdzD8n7vFZ79NyHxeR9EpJT8PiK9EqEp5QhNLkUgke0dUwhVaPYfiSMinfVEKBPM5LMIgnPhEpJHyIdrKKPAgJBcKELz4BZWCGVkCZRRZVBFl8M9phLusZW0XgFFeDHcQnKI9Gz4JVG+MH81lm09gUNnb+LUlbdx4tLbGLj4Ng4P3sGu49exfMcgFvYdQdPyA+hYcxh9O05i3/EruHr9Hew9eh5lDT1YuHQLtu07gROnLwiyfXwoOdRo4eDoDBtbOygovERQDlA1ey66Ohejs7MLbe1dWLJ629cuPjH//44WasMyphBZXW5hBb9QRJZCFVcDn8yFSJq9HFm1fSicvwb6nBZ4JtfDLboKrkQME8iWzGSpIorgn1YLdUIN3KLK4RpeRPsQiCTX8BIoIkqhiCyDgr5zi6qgc1TCLaYKyphqKGNnQ0VQxlbDjfZRx5G7TamDb/p8BGQ1IyhnESIK2xCW34rA7AXwpGvw9VRheYjIa0ZL30HsPn4Ne07eRP+Jm9h5/Aa2H7uOLUeuYc3eq2jfcBqzu/ejrG0Xqjv7Ma97N+Yv3UsiOIT1/adx/PzruPGj9/H2+5/inQ9/jGs/+hDXbr+PRW3d5N6VOHvxGm7e+Qi33v4Eb77H+/wV3v/kc3zy2c/xV//vV/jpX/8dbr/zCc5dvnl/77HBn6zfcXhLybz2aGfvqB/+qGFgTPZzbiHZdYrwwv9gYlUJtQguWoyGZfuxcf8lbDl4GRv2DKKqcwc8U+cL0lwjSgSYUDeyxMTKbsRW9NKxc8X3BhCZTGrcHCjjibD4eeLc7ol18Eiqhzq5AZqURnjROXnpTvt4p9QjpqwbBU3rUdfbj671R8l9nydyX8XOo1cRWdxJ4qiGKrwQfml1aFy2Dxv2X8Gq/pfRvekkOtcdQxtZdtuaI2hbO4D2jWcxu+cgChbuQPGi7ZjduQt1PXvQuGSvEEDzchLB6v3oWrMX56+8gVt3PsTg5etE+HWcvHAdZy7dxJFTl3H09GX6/hZefvVNXL72Nl594z3cePNDvPHWx3jr/c/w7kcGQbz38U/EtivkUXi/C6/c+tXRUxeLfrjlWXT+DI+ootdVbIkJ8+CRtgBZ8zdh6bZzWLPnEtYSlmw+gdymTfBIbhSECnIFsTUIyF6I/KYN8MlqEeTyOXipIpJVRLI7HeORMh/q1CZ4pjVDk74A2oxF8M5soWNa4ZPdCi/aHlncgUWrDmBN/3lsPXSFcBXbDr+C7UdexY6jr2LVznMIK+yAO4UAJSE4sxbl86gkK6pG1RwSQhN5gdZWtBJ6e3vR0NAgysOMvDKkz+1D8cKtmNO5Ew1LdqN52V4sXLFPoLJlo/BWDsEFFFrKsKF/ACs2HcD+Y4PYP/AyDp+6goMnLuPQycskhKsYOPsaTg5ew5mLN3Hh6m1cufaWAHuLGz/6ADdJFK/fep+I/5HwKgPnXhOfd+wbmPeDI9/MQWPlqw/5eV5+IRoam1Be24r8hdvQtv4UerYOYun2C1iw8hBiq1cJIpXxcw0EC3IbEFnWi8Sa1fBIXUDfz4d7CqOJPjcLIanTF8EzowWaTCI5qw3e2e3Q5XTAN7cL/vldtOwUQihZtBkrdpzDyp3nsWrXIPr6L2D17pdJgBcFWtceg1/mAiK+Ao7+qfAJDBdJWlxcHIKCgmBubi4wfvx4jBs3DpzVBwYGwsvLSyRt7oHJyKvvw+y2zajv3o75vTvRtGQXGmidc4rpDl4YPc4EJuaOcAzMFuGMElWU1XWibekmNHatR1P3Rizo3YxFy7ahfdUuLFm/H6u3HcGyDeSBdg2QIK7j4qs/wqXXyEO8fgfnyHMcOnkJ+wYuYt+xi3j5lVtfxWdVaH44GX1J86jJMyzejoqKQnp6OoqLi8VoWlX7NrSsO0Mx8wzqlx2EvrBHEMuEswgMBC9AeNlSBBYvESR7pC0USzWRrc5ohWdmGzRZ7dBkd8IrpwveuYuhy+uGT34PwstXIHHuGvjSenBxL12DkrEN5Lo3nkLXptNYvPksurecIwEaUEeuWptGnocSwOnWCowaNQqjR4/GzJkzwfcuZ+OOjo6YNWsWLCwsMHHiREyZMkVk5lZWVnDw0COxeCFK6peiekEfqura0Njcitk1tQgMChbCefbZZ0HdggkzbOBMyamjLgZ27gFw0EZSwpoFx6AcOATlkqfIF97CIaQAjgTPiByEZ9fDmZJWVVQpAtLmIrZoIZWTXSieRwJasRMb+09gL4lgS//RWz+cet03smgsWQtbjJ2dnehIXs+cswTz+06guvsAQop7DNYtLHohPATJrYJMJtUzs92ArA54Etma7C5ElS9GZmUL9EU90Ob1QlewBJFVq5HbvBW1S/aLDLy8ox9xNetQt+ww5q88hqa+ATSvPo6Fa05g0dpTJMBTWEifC5o3ipBh5x2HMWMn4Pnnnxf3OGPGDFhaWkKn0wkr53tn8jUajXgWJt7X11eUbiEhIdDH5SKpqBkJJS3wy2ikErEImvBM+EakwN/fH3q9Hp6enmIc4BkSgqU6Ek5UqThRdSJIfwgcJYRl1xHq4UQCcTTa7hich5TyVsSXdZCXOICmni3wT6qET1xx9A9CAI4K9UeRkZHiwbkD2aUGBAQgr3YFClr6EVKylAhveUC6WhBNJOcshia327CU1r1ye+BFZAeWLMOGnnmY19KNkIo+pDVsRkXHbszp3oeanv2o6T0glpWL94nEbM6Sw5i79Ahqlx9F/YoBNK46LsQ3e/FeIn8TtOlNmGHlIohhS2bwaJ1CoRD3zYS7ubkJ62dB8HPY2toKEfA+rq6uwruFZ8wWlmsXUgSHsDI4RlAoiSiHJiQJ0dHR4FFAXnI4Yc8x0dQOTgHpoiR1CMwRYWEonB4gS8BZn/lg/cF+JALHsBKkz+6Gb1wxxpmYws4z/I2nPx2bOUdj7+CI0LAI2Dq7w85RAS+dH+wdnCi5qod/8TKK121Eeptk3V2CbJlogfwl0BYsJSyDtnC5gF/pKsTUbEB283YS0S4UkpAKW/tR1LobxW17UNy+FyUd+1DWuR8Viw+iqucQZi85QiI4SiIYEGIoadmOrLo10EZkw8ZJCbUuCPrIJEQk5iI+sxQx6SWITitFYl4N0koakVPVisLaXlQ0r8ac9i2o7aESr3c/ipvXo6CgQAhAFVEIa/9M2AbmCRHYEykOtAwKjRS5QkxcPIlfL7wGe4+Jk6fBwS+FylsmkghlcvVErlhmijGMbyMDLjy28QAGMbAncAgtgjOJzUHlI8LXxKnm9138EsyfqgBcNfrlTk5OUOmT4EwqVVC9zskQ196apFoD+RTPRSwXcZzJ7yaX3gPv/F54k1v3FuQvFcuAkpWIql6D5HnrkVy7ASl1G5Fav0l4gPSGLchs3Iqspm3Iad6BPCrH8hftJFH0kyh2o7RjL8q7KBtfTKLo3Ctq9YYVR9G6/gw6Np1H15ZBwoUH6Nw8iHba3rL+LJrXnBKegz1Jeec+FJHocpu2IKNuHVILaoRF2zq4wsY/A5a+abAOyDKIILiQCMpAfEISvLTeUCpVCAuPRERUNHkWDVzJe1ipI+BIXsBAujG5BrJluNJ5XPXkLfRp0pJHLNOFMBzJeziE0LUoVwgJDQf3+XPPj4KjV0TWUxWAlYPbR46kSB6BU0RXUlZfTzF+kcHNs7WzWxdW/kcL9y5aQVgJ7+JVhD7oSvqgr1iLmLmbkNKwDamN25E2fwfSCRlNO5HZvAtZC/qRvXA3chbtQW7LHuS1kmtv24fCdrLQjgMo6TqIssWHUNF9BFW9R8kbHEPNsgHMW3EC9atOonH1aTStOYPmtQxaX30KDSuPY96yo5Sj0LHte4j0nciZvxlJc1YjrITyjnQeJJqDAIrrHNttlb6Y5ZUAC10yrHzTSQTZJIJcaMPT4UbEc0ixs7OHi6sC1tY2iI1PFKN/jp7BcKKKQ5AeYCBVhky0QiBNgIeg5XUGD1+zAOy5vAzNEkPKarUnXnzxRZjbuz+9IeOwrPrpTgr3+z5RefBOmku1+QLh5jU5FNcl0r0euPUV0H6L+FWCeEZ49Xok1m1BUv1WIwFsR3rTDiJ/J5G/i8jvJ/J3I5eQRwLIFwLYi0ISQZEQgSSEzoMolcRQ3n0YlT2HSRBHUC1A60w2eYrCRXTuho1IqF6J0EIqI6k0dE+YK1ysXVA+rPwyYOGdBCd1AOzt7UVu4OQbD3PPWMzSJsJSlyL2sSVPEJuaC0sra5FQ2ts7wJnyB1cSweTJk8kbRECp8ZEEQKQHpAkYrDzNiHQD8W6BqVDqDfMQshDYOzhQHmAflAefiHQKL36YYWoKU8L0WfZ7nt4bObEFSTZ2jtAnVaCxZzuy69cgrHQp/At6KLtfDC2VbZzNsydQG4E/e0qJn5Y8RGDxUioFlyO6ciXiqvuQVLMGqbXrkFFPOUDjJnLFm5HfvAWFC7eiaNE2CVtRuGALCgj5TbRP4wZk1dMxtWuRNnc1Umv6kDJnJZKqlyOuvAeRRR2IKmpFXEkrQjLroAgrgDW5crZoM3UMZrpHwlQVjhluoYQQzFAE0zIYFlY2oiowt7CGpTfvGw1zTZwQh6VPKgkgE2s3bBZkq9zd4UBC8accwIQ+8xRzSlq6SC6dfRMMVh+QCleCgiGRLEOpN5BvDN7OnsNBnw078jYB4QnCy/B1ZpqZgcrvM09NAC7qgF4XNzWpOwV2+hwoKUFShuZAEZQBRSAp1z8ZjvTgdt6xsNZEwdIjHOaqUJhSx85wDcR0Fz2mOQcQ/L+F6c5+AjOMYOrC8MdMhqs/zIxgrvDHLEUALNwMsHTTw1oVCFuPYNh7hhBCH8COoQ6FLcHGIwTW7sGwVAbR8XrMcguCuVsgZioCYUr3Z+7qK6oFHhtg988CmekRSV4gxhAKvJNh45uKBQsXiQRQ4aak5NcB+sBgMSVcV1+P6dOnixDi4hVisPqAFAFFAJNrgEy2SiBZWhq2sUi4irAnodmTCPyDwsU5vby0okKZONXs8lMTgI2T+1m11g+ufonCNZoqwzCVCJ3i4IPJdlqY2FA9bOWBiZYqTLBQYsIsN4IC42e5Yrw5w2UYSN/PMoCPeQALNyMoBSZaKsU1BKzcBSZZexDUmGyrwQxHHYkiAE5eodDoY6ANjKNlLNT+MVD5RsHVm5I0TRgJwyAICxKEGYnAwtGDYrm1EAELeIYylDxFBMzJC1iQF7DkUOAZJVwyl73sks3NZwnwtG5QcIghDEREwtldJyzflYxCIQsg4NsCUEoCMP7MouEE0o6STxaBt68/JlGu4eTsLAQwxdTi5acmgFk2Lj/29gsGlSLUKTHCfU518sdkex1MbL1gwiQQGRMslQbCJBL/KADXIaT/d/LHD0v+cAIwiICFxwKYRCI0IRGwIGc4+cLZKwzeQXHfEoGbLhIu2nA4kHewJa9gpSKPQJ7Ays5JjAlYOyrJ+sPIc4XAnARg6RkNW20c7HSJ9Ozx0HrrBCFmZuYiGczJyRFvFiWnpCI8MoqqAy0cnJUiBDjJU9jDwOXB94YykccA7KlstKPS0yGAk02lyDN45FLt6YmZFrZP5z3CyLSy582tHf/gHRAOe79UMV3rEV0CVViuCAHO/kkiabLTRMLKIxSzyKrYdc9w8sE0B29MsfMyeAgmycogFCZwEhFoIsNahcnW7gJTbDwwlWGrxjQ7hiem25N1O3jB1FELUydvmDnpYO7iQ6BsXeEHK6UeNu6GUMDWbSeFAIP7/2MIsFIZwoCFAFm+W6AIJWz57G6tPTgnCBLhy9ozEg4U0lzI67E1z3T0EglZdEws3D3UZPWhJIBcCgNBYr6fB55CQsNg7+gEbWypmOIOzKhDcFYDwnLmIyKvCVEFzYguXCCWYTkNUEaVwolqfoYjwYGSPzuyfke/ZJGMcrnJgnOgcGPnpNz8VASQP6fd3MsvFD6hyYgtaEJD10ZkVbYhLrcWwcll8I3ON7zmRC7NyScetl7Roh42J0ua6Wbo0OmujEAjSNvoO0MSFiK8CoeWmRx/yfrMKFkz94jCLHbDFIstveJgpY2HDVmjnU8yHPzTRK3NAy/ulJN4x1chIL0e+sz5iClqQUZ1J7ziyg0JoNYQumbS+Ti+Cyvn+6PrsDi4hNOSwM1omxnlB9Zqqr+9Y6D0T4A6KBnuQZS0+YRTvJ+Gl8aORUVlJVJS0zGW1nk+QKVSIT4xCRqK1/weQMX8pdiy9zS27T+LnQfPof/wIPYevSCwfucAOlfuQFHtYvFSioJKP5EcBiQLoQnydbEiIQ0kcQWHkIBtbeHq4b3wqQggLrMiQBtbRkleIkzMHfD8iy/huedG0YM/J8bAeTJEBk+ojBkz5sEkCS+H4rnnnhN1LS//uJ3Wn5PxPH33vBj8YIweMxbjJkzCmLHj6dpjMIquP+rFsRg1ehxeGDMeL4ydiBfHmmD0+CkYa2KKKbMcYaP0R2hSMWJyG6COnwNFdBVcoioIlWJK2iulAcH5HUia04eS1p3ILGsWdTeL04wSVytKYh1JAO76JGhDU6EOTsMMKydERccS2e5orkpDUlQoIqOikZScgtyCIjGzyJNKHuQdSmq70LJsG2paVqGgpgOJBXXQJxRDxaVfQCJUJCyVXxyJKlqEJYV3OFwpNDlpyetoY0SI4pJ03YaNeOmll8DzLxqtT/JTEYBvZGabvW8KXpps/oDohxHLYIvgWTdZAEwyT8bwZx7SlPHCCy8IGG9j8P4MXpePY7HwwAvPvsmiMRbdo/D8C2MwfroVzCipsw3IJpdbDl1KHQKzmhCQ0QBtQrVIuP7oGcLFuij/yGtY6wzuX0UeIDmzEBMmTITS3QOhOnds274NdY3ND67Fg0JqTw2FBw+46qLh6hsLV59YKHxioODPOkMS6qoNg7MnVS0qf9gqdLBy9sIsRzVBAwsXnQhN1m6+IgSUlJYimQQ2ZcpUeOt0oU9FAH4RaYMzKJazZT5ux8tgklkQTKK8ziKRIdQtLRmyKHgbexJZBI8S3eNi9ISpmGbvBQv3UCEIkeXLgz1U51v7psOWMnBlKM/rl8A1NA82fhmw0iXDVpeAorLZIs57ajRoa+8AT4qVV1Z/S5A8V+Li6gpHKkkZ9h6BRHQAlZZ+sHalCoXJdlDD1MYNUy2cMdncEZNm2ouJJBkmsyghtXMRVUlMbKwYYOKEUKfTqZ/OKGBMypqplKSxAGQX/ihLlDtcFsCECRNEicQEsxU/TAAMnrLl/XhmTd6Pj39cize+7rD70H2bWLpJ4w3+MHWlks5VD1PKRUw5FyFMZ4j8xJCbsFew1MSgqKQSWVlZKCwswtp168SPS4NDQpCRlSPuk/vE2sZWTI5ZOmth4eQFM3sPzLBRYpqVgkKTMyaZOWD8NCu8RKHqpYnTMHnaTJhbWBmE4+Iixv3Z8jmUMDj7t7CwhBWJwcfHZ8ZTEUBIRFymqZ0Hnn3eQAZbJT8wWzVbNFuqDP4sW7w8D8+EMphcGezS2ZqGgrczeH8eYJGTLFl47B343PK1HxeyZxH5B+UKJlQqTnbQYYqjnxjPmOYSiGkS6Qxe520sBBYBjwF0dnXzr3mQkJiM6tlzxKBRV1cnMrNzhJV663zEeICVrQOmWLiQZdth3BRzQfTYifT8U/l9BCsxWujrF4CwqAREJmQiKjkPVGkhMr0SMUmZcKasn8cZzMzMxIjj9OkzeMj53zQazbN/Co/PPSb+ew4QEDTNwl75zUSTqd8ikwnjpI8tXH6tisHrPFbOb98widOmTRMlFm9j8MPxd/yA8mtZ8ls5XItzScYJUFhYGMW/ZDEhwp3G55I9wnfhUSGDE0suSQ0i8CER+GKKkz8JQY+pLAQCi2Kq2OZPn/WwVEeIut+M7tVD7SneJeTnKCopFS+XBOgDxWcWwAxzK5jOshGDN1xd+Ospk49KQlgCCSUhF8GxWdAFxUGh1sHa1l48l6mpmYjz8vNxn3H/2FJ5yeseavUVeqbnHwPD8mq80ygJDzvBsxIeHEyKjGEChkJJcYnLH2Pwdn6hgknlB2BixeiaNMrGYJIZTLgYe6d9WRAM7kQWCXcKewJ+gYMHWniOnl8+4bd1+H09nn/nd/hk8LXlde50/p4hvwAiv+fHS95npr27YWyBxxUcvWHqpIOps48EnRhrEGMOVPvPdNKK17x48Id/Bm5Jz8DE83O6KtwQGhYuBoi4VPPz8xcjhfyjkJiEVOgjkuHhEwpHV3cxakjG8nvyjH9HJL9HffsJ4T8eViWxcXH/8TUV/FtFD48W2neShIkSJkgYL2GchLFGeEnCA9IZLzwCQ78fRVY9hdz7NdnNywmbbO3sARjsrtk1y/Gct/GDyHHd2BMw2bLly1YvxuGpE9n6eeCD46GzNAjCZHLH8lx9aGio8AqchMlv5sTHx4tOZ4+RmpoqXujg3/1xzOafavEveRl5eXkCvM7beT8+js/F5+aXO1gwfD0WEguLhc7xmT0AE67kXwyTEJgsTvgoOxfPwaGB75XFTs95n/rqPu1zn/rwG8LXhD8QviD8lvDvEr6QKyUZcpjjPuO+IkO5R5/5FXGuAvQEH/45BoGTQv5toYLAf0zlQLDlmXuCBQ/gEmYSTJ+RyOTfoI02wpjHxGjpWA9CE+Eg4f6TVgR/LhhbinGnyVWGnFjK4jQW4XAhSQZ/5u+MIe/j5OwiwBk5j87xPfCEEHsyDgEhJEzyWtwv9yTS5eUjQee5JyfWxs8ki4Ce4WPar5vQTJhLqCSwILIJqYQEfmFLEkggR20jgSglgXzLLYwzchsTJLcyRVKLDcGNX/3nAoB/8UXIlS46n9BL2Er4lPDlo7Luh303JE7fkyzj3uN21kNw/wnxSFENdcUMFhQLgb0Wj/Tx/D9P03L+wy+DsAjiExKF9yIhfkXnG4q7kvX/nvCfhF8T/oHwUykMvEl4jXCRcJZwnHCIsJewgcAjgLWE2YQyQgEhh5BOSOKxOkkAzFcwz95z9S5x6MU/v3xGcgl2/GYXQSMpJZ5HeiVVcYxZRlhP2C5d/AjhFGGQcJVwk3CH8L504z+mB/61PGgj49sjfMMmad88Aen3huCbPxGP5b34WZh8Jp6tnD0HewKenuWsn/8ZLD0zS8wNcNgiQbCYv5TcPOM3hH8h/A33FeEdiehzUt/uImwkrCLw2z7tEtkNEidVhFJCoUR4hmTxbJSxEun8m8IQiU9j4r0lntWS5xZE50knYxXVEBZIrmW1ZNX7CAPSDfLc8+uE24S3CR8Q/oLwE8LPCH8tPdjfEqH/QqTfNRbBI4RwfxhS7z3EI8ifjfFd+997hGAeJSRxLr4/2Q3LsZhFYEjIzIQIWBCcs3CWz3kKx38KLV/RsX8v9Q0bx48Ir0gWzWT3EzYR+ghLCZ2EVimk1kl8yIQXSF5XJtzYyiMkVx8ske4vuXxj0j2N8oMHIYAVNYcwT3LlrLYV0k3tldzOy5JCmfR3CR9Lrv5zws8lwv9BUvW/SUkMq/x3kuLvSp14j/DNUHwHsX8qjF3u9zn2rgwSwDfGuYX8oxI5DMjVigyK01/SvuzGLxCOEXYTNkuGxWR3Edokg2uUOGB3XkEokQjPfgThsmvXD7Fy7RArdzcinD29i5QcOj4jXbxJWnZIN7ZButljkpuXyWcX/5dGxP9KIv5fpfj1GymT/Z0U076QXN+XUpyT8QcJd4fgD4+Joef5PjC+5t0h8dj4/PK6eAYS7FcsBMJ9YzHIo5WcTNLya/r8E9r3JB2zg7CGsETq3wVGrryaUE4oljxxthS/U4zcebSRdQc9xLqHkq0aQrazBCbbXoKdVBVYPyPdVJvkepZIN7uNcECK85cI16UYL9eonxmJ4JeSEP5OEsM/Ev6J8M+SR/hXI/zLkOXQ72T885DP8jbj7fJx/ybh1xLY+/yHhN8MwW8fgd9Ix/+T9Bzstv9W8m4/l573M8n7vSe5cu6XK3KCRoTvJ2yS+nK+kUWXSdk5h9qsISTHGZEcNowLfxySZYt2MCLZRoK1VAJaSjmfXAqK3xM4SCfylFxImFQ+ZEluaK5RaOiVEpONkrL3SV7itBQmrkre4gbhltRJd6RcgfGW9PmOlOHelsD7vmGEm0M+35A6+9oweF3CNWm/G0bHXDfaLu//mhSHL0nu+YwU6g5Kie4GyRCWS8/cMSQJq5T6Jn9IEpYkJdBMaKRRIhYkuWm/h5Aqx2XZTbsZuenhiLV9CLGWRsTK5DLMpCpOrvsZPHcwXcIz/OeEkyVwyTdVwjSjneQDZ0onNJMuYiFd2Eq6GRvpBh0kOEkP4io9nEp6ULUET6kTNFKHaKWERScNavhK8DGCnwR/Ke7JCJQQJFlRsNT5MkKNEGK0T5DRsQHSeeVr+Ej3o5XKJmPCjGOrTNxQtyuTZ0ygrRGB30XirIeQaEzmDCNMN8I0CVONMMUIMt/ijymNa//xRsOIxpCHGCcZwcQIxgIaTkTTjW50xhBRGcPsITA3wiwj8c0ycmmWRrD6DlgbrRsfYznkfBbDWJX5EAszxpMQZUzWd5FmTNzkISQOxaSHYOgwsbz+rZG9lx6BsQ/BuCEY/5DPQ4U1/iHCGg6ThhHfpEeI0WSYjvpzYOj5jTvc5CGfJz0mhj73hCfA+O/Aw3gxxreGgB8HYx6yfBwYi+m7vn8cjH0MgT4K474nxj9kkmXcE3T4k2Ds98BLD5nweRQezAMMnQ948THE8OL3EJB83OPiSfcfeuzoYbaN/o7vH9UfjzrXmB8YhjNW+X6/d+f+b+KFR2x/FP4n7uNxzz36TxT16O9pIE9qjH92q3vSjvxTMWoYPEoUT7L9hacgtP9NfKe6h+uc77LOF5+AwKFkDvsOgtELK/L6c8O8+TJqmHO+8B0CGfUYYhvuvH+qR/tf96T/BXZKOpTOvYGPAAAAAElFTkSuQmCC\"\n  } ],\n  \"attributes\" : [ {\n    \"name\" : \"licenseplate\",\n    \"value\" : \"Porsche Taycan\"\n  }, {\n    \"name\" : \"service-favorites\",\n    \"value\" : \"taycan_charging_EU_v1\"\n  } ],\n  \"validFrom\" : \"2021-01-15T11:00:01.000Z\"\n} ]".data(using: .utf8)!
-    
+
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .useDefaultKeys
-    
+
     let decodedVehicles = try! decoder.decode([Vehicle].self, from: json)
     XCTAssertNotNil(decodedVehicles)
     XCTAssertEqual(1, decodedVehicles.count)
-    
+
     let decodedVehicle = decodedVehicles.first!
     XCTAssertEqual("VIN12345", decodedVehicle.vin)
     XCTAssertEqual("Taycan 4S", decodedVehicle.modelDescription)
     XCTAssertEqual("Y1ADB1", decodedVehicle.modelType)
     XCTAssertEqual("2021", decodedVehicle.modelYear)
-    
+
     XCTAssertEqual(2, decodedVehicle.attributes!.count)
-    
+
     let vehicleAttribute1 = decodedVehicle.attributes![0]
     XCTAssertNotNil(vehicleAttribute1)
     XCTAssertEqual("licenseplate", vehicleAttribute1.name)
     XCTAssertEqual("Porsche Taycan", vehicleAttribute1.value)
-    
+
     let vehicleAttribute2 = decodedVehicle.attributes![1]
     XCTAssertNotNil(vehicleAttribute2)
     XCTAssertEqual("service-favorites", vehicleAttribute2.name)
     XCTAssertEqual("taycan_charging_EU_v1", vehicleAttribute2.value)
-    
+
     XCTAssertEqual(5, decodedVehicle.pictures!.count)
-    
+
     let vehiclePicture1 = decodedVehicle.pictures![0]
     XCTAssertNotNil(vehiclePicture1)
     XCTAssertEqual(URL(string: "https://picserv.porsche.com/picserv/images-api/v1/ec2bed3b73260c6f0116e12f538b1ac6/5")!, vehiclePicture1.url)
@@ -127,7 +127,7 @@ final class ModelsTests: XCTestCase {
     XCTAssertEqual(1920, vehiclePicture1.width)
     XCTAssert(vehiclePicture1.transparent)
     XCTAssertNil(vehiclePicture1.placeholder)
-    
+
     let vehiclePicture2 = decodedVehicle.pictures![1]
     XCTAssertNotNil(vehiclePicture2)
     XCTAssertEqual(URL(string: "https://picserv.porsche.com/picserv/images-api/v1/c11fb8a8bb320523ce6591d52c68f5cf/4")!, vehiclePicture2.url)
@@ -137,7 +137,7 @@ final class ModelsTests: XCTestCase {
     XCTAssertEqual(1440, vehiclePicture2.width)
     XCTAssertFalse(vehiclePicture2.transparent)
     XCTAssertNil(vehiclePicture2.placeholder)
-    
+
     let vehiclePicture3 = decodedVehicle.pictures![2]
     XCTAssertNotNil(vehiclePicture3)
     XCTAssertEqual(URL(string: "https://picserv.porsche.com/picserv/images-api/v1/c11fb8a8bb320523ce6591d52c68f5cf/3")!, vehiclePicture3.url)
@@ -147,7 +147,7 @@ final class ModelsTests: XCTestCase {
     XCTAssertEqual(960, vehiclePicture3.width)
     XCTAssertFalse(vehiclePicture3.transparent)
     XCTAssertNil(vehiclePicture3.placeholder)
-    
+
     let vehiclePicture4 = decodedVehicle.pictures![3]
     XCTAssertNotNil(vehiclePicture4)
     XCTAssertEqual(URL(string: "https://picserv.porsche.com/picserv/images-api/v1/ec2bed3b73260c6f0116e12f538b1ac6/2")!, vehiclePicture4.url)
@@ -157,7 +157,7 @@ final class ModelsTests: XCTestCase {
     XCTAssertEqual(640, vehiclePicture4.width)
     XCTAssert(vehiclePicture4.transparent)
     XCTAssertNil(vehiclePicture4.placeholder)
-    
+
     let vehiclePicture5 = decodedVehicle.pictures![4]
     XCTAssertNotNil(vehiclePicture5)
     XCTAssertEqual(URL(string: "https://picserv.porsche.com/picserv/images-api/v1/ec2bed3b73260c6f0116e12f538b1ac6/1")!, vehiclePicture5.url)
@@ -168,53 +168,53 @@ final class ModelsTests: XCTestCase {
     XCTAssert(vehiclePicture5.transparent)
     XCTAssertNotNil(vehiclePicture5.placeholder)
   }
-  
+
   // MARK: - Summary tests
-  
+
   func testSummaryConstruction() {
     let summary = Summary(modelDescription: "A model description", nickName: nil)
     XCTAssertNotNil(summary)
     XCTAssertNil(summary.nickName)
   }
-  
+
   func testSummaryDecodingJsonIntoModel() {
     let json = "{\n \"modelDescription\": \"Taycan 4S\", \n \"nickName\": \"211-D-12345\"}".data(using: .utf8)!
-    
+
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .useDefaultKeys
-    
+
     let summary = try! decoder.decode(Summary.self, from: json)
     XCTAssertNotNil(summary)
     XCTAssertEqual("Taycan 4S", summary.modelDescription)
     XCTAssertEqual("211-D-12345", summary.nickName!)
   }
-  
+
   func testSummaryDecodingJsonIntoModelWithNoNickname() {
     let json = "{\"modelDescription\": \"Taycan 4S\"}".data(using: .utf8)!
-    
+
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .useDefaultKeys
-    
+
     let summary = try! decoder.decode(Summary.self, from: json)
     XCTAssertNotNil(summary)
     XCTAssertEqual("Taycan 4S", summary.modelDescription)
     XCTAssertNil(summary.nickName)
   }
-  
+
   // MARK: - Position tests
-  
+
   func testPositionDecodingJsonIntoModel() {
     let position = buildPosition()
-    
+
     XCTAssertNotNil(position)
     XCTAssertNotNil(position.carCoordinate)
     XCTAssertEqual(53.365771, position.carCoordinate.latitude)
     XCTAssertEqual(-6.330550, position.carCoordinate.longitude)
     XCTAssertEqual(68, position.heading)
   }
-  
+
   // MARK: - Capabilities tests
-  
+
   func testCapabilitiesConstruction() {
     let capabilities = Capabilities(engineType: "Test Engine Type", carModel: "Test Car Model")
     XCTAssertEqual("Test Engine Type", capabilities.engineType)
@@ -228,10 +228,10 @@ final class ModelsTests: XCTestCase {
     XCTAssertTrue(capabilities.heatingCapabilities.frontSeatHeatingAvailable)
     XCTAssertFalse(capabilities.heatingCapabilities.rearSeatHeatingAvailable)
   }
-  
+
   func testCapabilitiesDecodingJsonIntoModel() {
     let capabilities = buildCapabilites()
-    
+
     XCTAssertNotNil(capabilities)
     XCTAssertNotNil(capabilities.heatingCapabilities)
     XCTAssertNotNil(capabilities.onlineRemoteUpdateStatus)
@@ -247,19 +247,19 @@ final class ModelsTests: XCTestCase {
     XCTAssertEqual("RIGHT", capabilities.steeringWheelPosition)
     XCTAssertTrue(capabilities.hasHonkAndFlash)
   }
-  
+
   // MARK: - E-Mobility tests
-  
+
   func testEmobilityDecodingJsonIntoModel() {
     let emobility = buildEmobilityWhenNotCharging()
-    
+
     XCTAssertNotNil(emobility)
     XCTAssertNotNil(emobility.batteryChargeStatus)
     XCTAssertNotNil(emobility.directCharge)
     XCTAssertNotNil(emobility.directClimatisation)
-    
+
     let batteryChargeStatus = emobility.batteryChargeStatus
-    
+
     XCTAssertEqual("DISCONNECTED", batteryChargeStatus.plugState)
     XCTAssertEqual("UNLOCKED", batteryChargeStatus.lockState)
     XCTAssertEqual("OFF", batteryChargeStatus.chargingState)
@@ -270,7 +270,7 @@ final class ModelsTests: XCTestCase {
     XCTAssertEqual("OFF", batteryChargeStatus.chargingMode)
     XCTAssertEqual(56, batteryChargeStatus.stateOfChargeInPercentage)
     XCTAssertNil(batteryChargeStatus.remainingChargeTimeUntil100PercentInMinutes)
-    
+
     XCTAssertNotNil(batteryChargeStatus.remainingERange)
     let remainingERange = batteryChargeStatus.remainingERange
     XCTAssertEqual(191, remainingERange.value)
@@ -279,43 +279,43 @@ final class ModelsTests: XCTestCase {
     XCTAssertEqual("KILOMETER", remainingERange.originalUnit)
     XCTAssertEqual(191, remainingERange.valueInKilometers)
     XCTAssertEqual("GRAY_SLICE_UNIT_KILOMETER", remainingERange.unitTranslationKey)
-    
+
     XCTAssertNil(batteryChargeStatus.remainingCRange)
     XCTAssertEqual("2021-02-19T01:09", batteryChargeStatus.chargingTargetDateTime)
     XCTAssertNil(batteryChargeStatus.status)
-    
+
     XCTAssertNotNil(batteryChargeStatus.chargeRate)
     let chargeRate = batteryChargeStatus.chargeRate
     XCTAssertEqual(0, chargeRate.value)
     XCTAssertEqual("KM_PER_MIN", chargeRate.unit)
     XCTAssertEqual(0, chargeRate.valueInKmPerHour)
     XCTAssertEqual("EC.COMMON.UNIT.KM_PER_MIN", chargeRate.unitTranslationKey)
-    
+
     XCTAssertEqual(0, batteryChargeStatus.chargingPower)
     XCTAssertFalse(batteryChargeStatus.chargingInDCMode)
-    
+
     let directCharge = emobility.directCharge
     XCTAssertFalse(directCharge.disabled)
     XCTAssertFalse(directCharge.isActive)
-    
+
     let directClimatisation = emobility.directClimatisation
     XCTAssertEqual("OFF", directClimatisation.climatisationState)
     XCTAssertNil(directClimatisation.remainingClimatisationTime)
-    
+
     XCTAssertEqual("NOT_CHARGING", emobility.chargingStatus)
-    
+
     XCTAssertNotNil(emobility.chargingProfiles)
     let chargingProfiles = emobility.chargingProfiles
     XCTAssertEqual(4, chargingProfiles.currentProfileId)
     XCTAssertNotNil(chargingProfiles.profiles)
     XCTAssertEqual(2, chargingProfiles.profiles.count)
-    
+
     let chargingProfile1 = chargingProfiles.profiles[0]
     XCTAssertNotNil(chargingProfile1)
     XCTAssertEqual(4, chargingProfile1.profileId)
     XCTAssertEqual("Allgemein", chargingProfile1.profileName)
     XCTAssertTrue(chargingProfile1.profileActive)
-    
+
     XCTAssertNotNil(chargingProfile1.chargingOptions)
     let chargingOptionsForChargingProfile1 = chargingProfile1.chargingOptions
     XCTAssertEqual(100, chargingOptionsForChargingProfile1.minimumChargeLevel)
@@ -323,18 +323,18 @@ final class ModelsTests: XCTestCase {
     XCTAssertFalse(chargingOptionsForChargingProfile1.preferredChargingEnabled)
     XCTAssertEqual("00:00", chargingOptionsForChargingProfile1.preferredChargingTimeStart)
     XCTAssertEqual("06:00", chargingOptionsForChargingProfile1.preferredChargingTimeEnd)
-    
+
     XCTAssertNotNil(chargingProfile1.position)
     let positionForChargingProfile1 = chargingProfile1.position
     XCTAssertEqual(0, positionForChargingProfile1.latitude)
     XCTAssertEqual(0, positionForChargingProfile1.longitude)
-    
+
     let chargingProfile2 = chargingProfiles.profiles[1]
     XCTAssertNotNil(chargingProfile2)
     XCTAssertEqual(5, chargingProfile2.profileId)
     XCTAssertEqual("HOME", chargingProfile2.profileName)
     XCTAssertTrue(chargingProfile2.profileActive)
-    
+
     XCTAssertNotNil(chargingProfile2.chargingOptions)
     let chargingOptionsForChargingProfile2 = chargingProfile2.chargingOptions
     XCTAssertEqual(25, chargingOptionsForChargingProfile2.minimumChargeLevel)
@@ -342,17 +342,17 @@ final class ModelsTests: XCTestCase {
     XCTAssertTrue(chargingOptionsForChargingProfile2.preferredChargingEnabled)
     XCTAssertEqual("23:00", chargingOptionsForChargingProfile2.preferredChargingTimeStart)
     XCTAssertEqual("08:00", chargingOptionsForChargingProfile2.preferredChargingTimeEnd)
-    
+
     XCTAssertNotNil(chargingProfile2.position)
     let positionForChargingProfile2 = chargingProfile2.position
     XCTAssertEqual(53.365771, positionForChargingProfile2.latitude)
     XCTAssertEqual(-6.330550, positionForChargingProfile2.longitude)
-    
+
     XCTAssertNil(emobility.climateTimer)
-    
+
     XCTAssertNotNil(emobility.timers)
     XCTAssertEqual(1, emobility.timers!.count)
-    
+
     let timer = emobility.timers![0]
     XCTAssertNotNil(timer)
     XCTAssertEqual("1", timer.timerID)
@@ -366,7 +366,7 @@ final class ModelsTests: XCTestCase {
     XCTAssertTrue(timer.chargeOption)
     XCTAssertEqual(80, timer.targetChargeLevel)
     XCTAssertFalse(timer.climatisationTimer)
-    
+
     XCTAssertNotNil(timer.weekDays)
     let weekdays = timer.weekDays
     XCTAssertTrue(weekdays.SUNDAY)
@@ -377,30 +377,30 @@ final class ModelsTests: XCTestCase {
     XCTAssertTrue(weekdays.FRIDAY)
     XCTAssertTrue(weekdays.SATURDAY)
   }
-  
+
   // MARK: - Flash & Honk
-  
+
   func testFlashDecodingJsonIntoModel() {
     let remoteCommandAccepted = buildRemoteCommandAccepted()
-    
+
     XCTAssertNotNil(remoteCommandAccepted)
     XCTAssertEqual("2119999", remoteCommandAccepted.id)
     XCTAssertEqual(ISO8601DateFormatter().date(from: "2022-12-27T13:19:23Z"), remoteCommandAccepted.lastUpdated)
   }
-  
+
   // MARK: – Remote Command Status
-  
+
   func testRemoteCommandStatusInProgress() {
     let remoteCommandStatus = buildRemoteCommandStatusInProgress()
-    
+
     XCTAssertNotNil(remoteCommandStatus)
     XCTAssertEqual("IN_PROGRESS", remoteCommandStatus.status)
     XCTAssertEqual(RemoteCommandStatus.RemoteStatus.inProgress, remoteCommandStatus.remoteStatus)
   }
-  
+
   func testRemoteCommandStatusSuccess() {
     let remoteCommandStatus = buildRemoteCommandStatusInSuccess()
-    
+
     XCTAssertNotNil(remoteCommandStatus)
     XCTAssertEqual("SUCCESS", remoteCommandStatus.status)
     XCTAssertEqual(RemoteCommandStatus.RemoteStatus.success, remoteCommandStatus.remoteStatus)
@@ -412,50 +412,50 @@ final class ModelsTests: XCTestCase {
     XCTAssertNotNil(remoteCommandStatus)
     XCTAssertNil(remoteCommandStatus.remoteStatus)
   }
-  
+
   // MARK: - Private functions
-  
+
   private func buildPosition() -> Position {
     let json = "{\"carCoordinate\": {\"geoCoordinateSystem\": \"WGS84\",\"latitude\": 53.365771, \"longitude\": -6.330550}, \"heading\": 68}".data(using: .utf8)!
-    
+
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .useDefaultKeys
-    
+
     return try! decoder.decode(Position.self, from: json)
   }
-  
+
   private func buildEmobilityWhenNotCharging() -> Emobility {
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .useDefaultKeys
-    
+
     return try! decoder.decode(Emobility.self, from: kEmobilityNotChargingJson)
   }
-  
+
   private func buildRemoteCommandAccepted() -> RemoteCommandAccepted {
     let json = "{\"id\" : \"2119999\", \"lastUpdated\" : \"2022-12-27T13:19:23Z\"}".data(using: .utf8)!
-    
+
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .useDefaultKeys
     decoder.dateDecodingStrategy = .iso8601
-    
+
     return try! decoder.decode(RemoteCommandAccepted.self, from: json)
   }
-  
+
   private func buildRemoteCommandStatusInProgress() -> RemoteCommandStatus {
     let json = "{\"status\" : \"IN_PROGRESS\"}".data(using: .utf8)!
-    
+
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .useDefaultKeys
-    
+
     return try! decoder.decode(RemoteCommandStatus.self, from: json)
   }
-  
+
   private func buildRemoteCommandStatusInSuccess() -> RemoteCommandStatus {
     let json = "{\"status\" : \"SUCCESS\"}".data(using: .utf8)!
-    
+
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .useDefaultKeys
-    
+
     return try! decoder.decode(RemoteCommandStatus.self, from: json)
   }
 

--- a/Tests/PorscheConnectTests/NetworkClientTests.swift
+++ b/Tests/PorscheConnectTests/NetworkClientTests.swift
@@ -8,19 +8,19 @@ fileprivate struct HelloWorld: Codable {
 final class NetworkClientTests: BaseMockNetworkTestCase {
 
   // MARK: - Properties
-  
+
   var client: NetworkClient!
   let mockNetworkRoutes = MockNetworkRoutes()
-  
+
   // MARK: - Lifecycle
-  
+
   override func setUp() {
     super.setUp()
     client = NetworkClient()
   }
-  
+
   // MARK: - Tests
-  
+
   func testGetSuccessful() async {
     let url = URL(string: "http://localhost:\(kTestServerPort)/hello_world.json")!
     mockNetworkRoutes.mockGetHelloWorldSuccessful(router: MockServer.shared.router)
@@ -28,13 +28,13 @@ final class NetworkClientTests: BaseMockNetworkTestCase {
 
     let result = try! await client.get(HelloWorld.self, url: url)
     expectation.fulfill()
-    
+
     XCTAssertEqual("Hello World!", result.data!.message)
     XCTAssertEqual(200, result.response!.statusCode)
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testGetFailure() async {
     let url = URL(string: "http://localhost:\(kTestServerPort)/hello_world.json")!
     mockNetworkRoutes.mockGetHelloWorldFailure(router: MockServer.shared.router)
@@ -47,46 +47,46 @@ final class NetworkClientTests: BaseMockNetworkTestCase {
       XCTAssertEqual(HttpStatusCode.Unauthorized, error as! HttpStatusCode)
     }
 
-   await  waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+    await  waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testPostSuccess() async {
     let url = URL(string: "http://localhost:\(kTestServerPort)/hello_world.json")!
     mockNetworkRoutes.mockGetHelloWorldSuccessful(router: MockServer.shared.router)
     let expectation = expectation(description: "Network Expectation")
     let body = ["param_key": "param_value"]
-    
+
     let result = try! await client.post(HelloWorld.self, url: url, body: buildPostFormBodyFrom(dictionary: body))
     expectation.fulfill()
-    
+
     XCTAssertEqual("Hello World!", result.data!.message)
     XCTAssertEqual(200, result.response!.statusCode)
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-      
+
   func testUrlExtensionAddSingleParam() {
     let url = URL(string: "https://api.porsche.example")!.addParams(params: ["param_key": "param_value"])
     XCTAssert(url.query!.contains("param_key=param_value"))
   }
-  
+
   func testUrlExtensionAddMultipleParams() {
     let url = URL(string: "https://api.porsche.example")!.addParams(params: ["param_key_1": "param_value_1", "param_key_2": "param_value_2"])
     XCTAssert(url.query!.contains("param_key_1=param_value_1"))
     XCTAssert(url.query!.contains("param_key_2=param_value_2"))
   }
-  
+
   func testUrlExtensionAddMultipleParamsToUrlWithExistingParam() {
     let url = URL(string: "https://api.porsche.example?param_key_1=param_value_1")!.addParams(params: ["param_key_2": "param_value_2"])
     XCTAssert(url.query!.contains("param_key_1=param_value_1"))
     XCTAssert(url.query!.contains("param_key_2=param_value_2"))
   }
-  
+
   func testBuildPostFormBodySingleKey() {
     let data = buildPostFormBodyFrom(dictionary: ["param_key": "param_value"])
     XCTAssertEqual("param_key=param_value", String(data: data, encoding: .utf8))
   }
-  
+
   func testBuildPostFormBodyMultipleKeys() {
     let data = buildPostFormBodyFrom(dictionary: ["param_key_1": "param_value_1", "param_key_2": "param_value_2"])
     let query = String(data: data, encoding: .utf8)!

--- a/Tests/PorscheConnectTests/NetworkRoutesTests.swift
+++ b/Tests/PorscheConnectTests/NetworkRoutesTests.swift
@@ -2,35 +2,35 @@ import XCTest
 @testable import PorscheConnect
 
 final class NetworkRoutesTests: XCTestCase {
-  
+
   var capabilities: Capabilities?
-  
+
   override func setUp() {
     super.setUp()
     capabilities = buildCapabilites()
   }
-  
+
   func testApplicationRedirectURLPortal() {
     let application = Application.api
     XCTAssertEqual(URL(string: "https://my.porsche.com/core/de/de_DE")!, application.redirectURL)
   }
-  
+
   func testApplicationClientIdCarControl() {
     let application = Application.carControl
     XCTAssertEqual("Ux8WmyzsOAGGmvmWnW7GLEjIILHEztAs", application.clientId)
   }
-  
+
   func testApplicationRedirectURLCarControl() {
     let application = Application.carControl
     XCTAssertEqual(URL(string: "https://my.porsche.com/myservices/auth/auth.html")!, application.redirectURL)
   }
-  
+
   func testNetworkRoutesProduction() {
     let networkRoute = NetworkRoutes(environment: .production)
     XCTAssertEqual(URL(string: "https://login.porsche.com/auth/api/v1/de/de_DE/public/login")!, networkRoute.loginAuthURL)
     XCTAssertEqual(URL(string: "https://login.porsche.com/as/authorization.oauth2")!, networkRoute.apiAuthURL)
     XCTAssertEqual(URL(string: "https://login.porsche.com/as/token.oauth2")!, networkRoute.apiTokenURL)
-    
+
     let vehicle = Vehicle(vin: "12345X")
     XCTAssertEqual(URL(string: "https://api.porsche.com/service-vehicle/vehicle-summary/12345X"), networkRoute.vehicleSummaryURL(vehicle: vehicle))
     XCTAssertEqual(URL(string: "https://api.porsche.com/service-vehicle/car-finder/12345X/position"), networkRoute.vehiclePositionURL(vehicle: vehicle))
@@ -40,13 +40,13 @@ final class NetworkRoutesTests: XCTestCase {
     XCTAssertEqual(URL(string: "https://api.porsche.com/service-vehicle/honk-and-flash/12345X/honk-and-flash"), networkRoute.vehicleHonkAndFlashURL(vehicle: vehicle))
     XCTAssertEqual(URL(string: "https://api.porsche.com/service-vehicle/honk-and-flash/12345X/123456/status"), networkRoute.vehicleHonkAndFlashRemoteCommandStatusURL(vehicle: vehicle, remoteCommand: RemoteCommandAccepted(id: "123456", lastUpdated: Date())))
   }
-  
+
   func testNetworkRoutesTest() {
     let networkRoute = NetworkRoutes(environment: .test)
     XCTAssertEqual(URL(string: "http://localhost:\(kTestServerPort)/auth/api/v1/ie/en_IE/public/login")!, networkRoute.loginAuthURL)
     XCTAssertEqual(URL(string: "http://localhost:\(kTestServerPort)/as/authorization.oauth2")!, networkRoute.apiAuthURL)
     XCTAssertEqual(URL(string: "http://localhost:\(kTestServerPort)/as/token.oauth2")!, networkRoute.apiTokenURL)
-    
+
     let vehicle = Vehicle(vin: "12345X")
     XCTAssertEqual(URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/vehicle-summary/12345X"), networkRoute.vehicleSummaryURL(vehicle: vehicle))
     XCTAssertEqual(URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/car-finder/12345X/position"), networkRoute.vehiclePositionURL(vehicle: vehicle))

--- a/Tests/PorscheConnectTests/PorscheConnect+AuthTests.swift
+++ b/Tests/PorscheConnectTests/PorscheConnect+AuthTests.swift
@@ -2,79 +2,79 @@ import XCTest
 @testable import PorscheConnect
 
 final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
-  
+
   // MARK: - Properties
-  
+
   var connect: PorscheConnect!
   let mockNetworkRoutes = MockNetworkRoutes()
-  
+
   // MARK: - Setup
-  
+
   override func setUp() {
     super.setUp()
     connect = PorscheConnect(username: "homer.simpson@icloud.example", password: "Duh!", environment: .test)
   }
-  
+
   // MARK: - Tests
-  
+
   func testRequestTokenSuccessful() async {
     let application: Application = .api
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: MockServer.shared.router)
-    
+
     XCTAssertFalse(connect.authorized(application: application))
     let porscheAuth = try! await connect.auth(application: application)
     expectation.fulfill()
-    
+
     XCTAssert(connect.authorized(application: application))
     assertCookiesPresent()
-    
+
     XCTAssertNotNil(porscheAuth)
     XCTAssertEqual("Kpjg2m1ZXd8GM0pvNIB3jogWd0o6", porscheAuth.accessToken)
     XCTAssertEqual("eyJhbGciOiJSUzI1NiIsImtpZCI6IjE1bF9LeldTV08tQ1ZNdXdlTmQyMnMifQ.eyJzdWIiOiI4N3VnOGJobXZydnF5bTFrIiwiYXVkIjoiVFo0VmY1d25LZWlwSnh2YXRKNjBsUEhZRXpxWjRXTnAiLCJqdGkiOiJmTldhWEE4RTBXUzNmVzVZU0VmNFRDIiwiaXNzIjoiaHR0cHM6XC9cL2xvZ2luLnBvcnNjaGUuY29tIiwiaWF0IjoxNjEyNzQxNDA4LCJleHAiOjE2MTI3NDE3MDgsInBpLnNyaSI6InNoeTN3aDN4RFVWSFlwd0pPYmpQdHJ5Y2FpOCJ9.EsgxbnDCdEC0O8b05B_VJoe09etxcQOqhj4bRkR-AOwZrFV0Ba5LGkUFD_8GxksWuCn9W_bG_vHNOxpcum-avI7r2qY3N2iMJHZaOc0Y-NqBPCu5kUN3F5oh8e7aDbBKQI_ZWTxRdMvcTC8zKJRZf0Ud2YFQSk6caGwmqJ5OE_OB38_ovbAiVRgV_beHePWpEkdADKKtlF5bmSViHOoUOs8x6j21mCXDiuMPf62oRxU4yPN-AS4wICtz22dabFgdjIwOAFm651098z2zwEUEAPAGkcRKuvSHlZ8OAvi4IXSFPXBdCfcfXRk5KdCXxP1xaZW0ItbrQZORdI12hVFoUQ", porscheAuth.idToken)
     XCTAssertEqual("Bearer", porscheAuth.tokenType)
     XCTAssertEqual(7199, porscheAuth.expiresIn)
-    
+
     let portalAuth = connect.auths[application]!
     XCTAssertNotNil(portalAuth)
-    
+
     XCTAssertEqual("Kpjg2m1ZXd8GM0pvNIB3jogWd0o6", portalAuth.accessToken)
     XCTAssertEqual("eyJhbGciOiJSUzI1NiIsImtpZCI6IjE1bF9LeldTV08tQ1ZNdXdlTmQyMnMifQ.eyJzdWIiOiI4N3VnOGJobXZydnF5bTFrIiwiYXVkIjoiVFo0VmY1d25LZWlwSnh2YXRKNjBsUEhZRXpxWjRXTnAiLCJqdGkiOiJmTldhWEE4RTBXUzNmVzVZU0VmNFRDIiwiaXNzIjoiaHR0cHM6XC9cL2xvZ2luLnBvcnNjaGUuY29tIiwiaWF0IjoxNjEyNzQxNDA4LCJleHAiOjE2MTI3NDE3MDgsInBpLnNyaSI6InNoeTN3aDN4RFVWSFlwd0pPYmpQdHJ5Y2FpOCJ9.EsgxbnDCdEC0O8b05B_VJoe09etxcQOqhj4bRkR-AOwZrFV0Ba5LGkUFD_8GxksWuCn9W_bG_vHNOxpcum-avI7r2qY3N2iMJHZaOc0Y-NqBPCu5kUN3F5oh8e7aDbBKQI_ZWTxRdMvcTC8zKJRZf0Ud2YFQSk6caGwmqJ5OE_OB38_ovbAiVRgV_beHePWpEkdADKKtlF5bmSViHOoUOs8x6j21mCXDiuMPf62oRxU4yPN-AS4wICtz22dabFgdjIwOAFm651098z2zwEUEAPAGkcRKuvSHlZ8OAvi4IXSFPXBdCfcfXRk5KdCXxP1xaZW0ItbrQZORdI12hVFoUQ", portalAuth.idToken)
     XCTAssertEqual("Bearer", portalAuth.tokenType)
     XCTAssertEqual(7199, portalAuth.expiresIn)
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testRequestTokenFailureAtLoginToRetrieveCookies() async {
     let application: Application = .api
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthFailure(router: MockServer.shared.router)
-    
+
     XCTAssertFalse(connect.authorized(application: application))
-    
+
     do {
       _ = try await connect.auth(application: application)
     } catch {
       expectation.fulfill()
-      
+
       XCTAssertFalse(connect.authorized(application: application))
       assertCookiesNotPresent()
     }
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testRequestTokenFailureAtGetApiAuthCode() async {
     let application: Application = .api
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockGetApiAuthFailure(router: MockServer.shared.router)
-    
+
     XCTAssertFalse(connect.authorized(application: application))
-    
+
     do {
       _ = try await connect.auth(application: application)
     } catch {
@@ -82,19 +82,19 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
       XCTAssertFalse(connect.authorized(application: application))
       assertCookiesPresent()
     }
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testRequestTokenFailureAtGetApiAuthToken() async {
     let application: Application = .api
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostApiTokenFailure(router: MockServer.shared.router)
-    
+
     XCTAssertFalse(connect.authorized(application: application))
-    
+
     do {
       _ = try await connect.auth(application: application)
     } catch {
@@ -102,21 +102,21 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
       XCTAssertFalse(connect.authorized(application: application))
       assertCookiesPresent()
     }
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   // MARK: - Private functions
-  
+
   private func assertCookiesNotPresent() {
     let cookies = HTTPCookieStorage.shared.cookies!
     XCTAssertEqual(0, cookies.count)
   }
-  
+
   private func assertCookiesPresent() {
     let cookies = HTTPCookieStorage.shared.cookies!
     XCTAssertEqual(1, cookies.count)
-    
+
     let cookie = cookies.first!
     XCTAssertEqual("CIAM.status", cookie.name)
     XCTAssertEqual("mockValue", cookie.value)

--- a/Tests/PorscheConnectTests/PorscheConnect+CarControlTests.swift
+++ b/Tests/PorscheConnectTests/PorscheConnect+CarControlTests.swift
@@ -2,69 +2,69 @@ import XCTest
 @testable import PorscheConnect
 
 final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
-  
+
   // MARK: - Properties
-  
+
   var connect: PorscheConnect!
   let mockNetworkRoutes = MockNetworkRoutes()
   let application: Application = .carControl
   let vehicle = Vehicle(vin: "A1234")
   let capabilites = buildCapabilites()
-  
+
   // MARK: - Lifecycle
-  
+
   override func setUp() {
     super.setUp()
     connect = PorscheConnect(username: "homer.simpson@icloud.example", password: "Duh!", environment: .test)
     connect.auths[application] = kTestPorschePortalAuth
   }
-  
+
   // MARK: - Summary Tests
-  
+
   func testSummaryAuthRequiredSuccessful() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    
+
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockGetSummarySuccessful(router: MockServer.shared.router)
-    
+
     XCTAssertFalse(connect.authorized(application: application))
-    
+
     let result = try! await connect.summary(vehicle: vehicle)
-    
+
     expectation.fulfill()
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.summary)
     assertSummary(result.summary!)
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testSummaryNoAuthRequiredSuccessful() async {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetSummarySuccessful(router: MockServer.shared.router)
-    
+
     XCTAssert(connect.authorized(application: application))
-    
+
     let result = try! await connect.summary(vehicle: vehicle)
-    
+
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.summary)
     assertSummary(result.summary!)
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testSummaryNoAuthRequiredFailure() async {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetSummaryFailure(router: MockServer.shared.router)
-    
+
     XCTAssert(connect.authorized(application: application))
-    
+
     do {
       _ = try await connect.summary(vehicle: vehicle)
     } catch {
@@ -72,17 +72,17 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
       XCTAssert(connect.authorized(application: application))
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testSummaryAuthRequiredAuthFailure() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthFailure(router: MockServer.shared.router)
-    
+
     XCTAssertFalse(connect.authorized(application: application))
-    
+
     do {
       _ = try await connect.summary(vehicle: vehicle)
     } catch {
@@ -90,12 +90,12 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
       XCTAssertFalse(connect.authorized(application: application))
       XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
     }
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   // MARK: - Position Tests
-  
+
   func testPositionAuthRequiredSuccessful() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
@@ -103,304 +103,304 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockGetPositionSuccessful(router: MockServer.shared.router)
-    
+
     XCTAssertFalse(connect.authorized(application: application))
-    
+
     let result = try! await connect.position(vehicle: vehicle)
-    
+
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
     XCTAssertNotNil(result.response)
     XCTAssertNotNil(result.position)
     assertPosition(result.position!)
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
-    func testPositionNoAuthRequiredSuccessful() async {
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockGetPositionSuccessful(router: MockServer.shared.router)
-  
-      XCTAssert(connect.authorized(application: application))
-  
-      let result = try! await connect.position(vehicle: vehicle)
-      
+
+  func testPositionNoAuthRequiredSuccessful() async {
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockGetPositionSuccessful(router: MockServer.shared.router)
+
+    XCTAssert(connect.authorized(application: application))
+
+    let result = try! await connect.position(vehicle: vehicle)
+
+    expectation.fulfill()
+    XCTAssert(connect.authorized(application: application))
+    XCTAssertNotNil(result.response)
+    XCTAssertNotNil(result.position)
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  func testPositionNoAuthRequiredFailure() async {
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockGetPositionFailure(router: MockServer.shared.router)
+
+    XCTAssert(connect.authorized(application: application))
+
+    do {
+      _ = try await connect.position(vehicle: vehicle)
+    } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
-      XCTAssertNotNil(result.response)
-      XCTAssertNotNil(result.position)
-  
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+      XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
-  
-    func testPositionNoAuthRequiredFailure() async {
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockGetPositionFailure(router: MockServer.shared.router)
-  
-      XCTAssert(connect.authorized(application: application))
-  
-      do {
-        _ = try await connect.position(vehicle: vehicle)
-      } catch {
-        expectation.fulfill()
-        XCTAssert(connect.authorized(application: application))
-        XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
-      }
-      
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
-    }
-  
-    func testPositionAuthRequiredAuthFailure() async {
-      connect.auths[application] = nil
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockPostLoginAuthFailure(router: MockServer.shared.router)
-  
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  func testPositionAuthRequiredAuthFailure() async {
+    connect.auths[application] = nil
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockPostLoginAuthFailure(router: MockServer.shared.router)
+
+    XCTAssertFalse(connect.authorized(application: application))
+
+    do {
+      _ = try await connect.position(vehicle: vehicle)
+    } catch {
+      expectation.fulfill()
       XCTAssertFalse(connect.authorized(application: application))
-  
-      do {
-        _ = try await connect.position(vehicle: vehicle)
-      } catch {
-        expectation.fulfill()
-        XCTAssertFalse(connect.authorized(application: application))
-        XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
-      }
-        
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+      XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
     }
-  
-    // MARK: - Capabilities Tests
-  
-    func testCapabilitiesAuthRequiredSuccessful() async {
-      connect.auths[application] = nil
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
-      mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
-      mockNetworkRoutes.mockPostApiTokenSuccessful(router: MockServer.shared.router)
-      mockNetworkRoutes.mockGetCapabilitiesSuccessful(router: MockServer.shared.router)
-  
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  // MARK: - Capabilities Tests
+
+  func testCapabilitiesAuthRequiredSuccessful() async {
+    connect.auths[application] = nil
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
+    mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
+    mockNetworkRoutes.mockPostApiTokenSuccessful(router: MockServer.shared.router)
+    mockNetworkRoutes.mockGetCapabilitiesSuccessful(router: MockServer.shared.router)
+
+    XCTAssertFalse(connect.authorized(application: application))
+
+    let result = try! await connect.capabilities(vehicle: vehicle)
+
+    expectation.fulfill()
+    XCTAssert(connect.authorized(application: application))
+    XCTAssertNotNil(result.response)
+    XCTAssertNotNil(result.capabilities)
+    assertCapabilities(result.capabilities!)
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  func testCapabilitiesNoAuthRequiredSuccessful() async {
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockGetCapabilitiesSuccessful(router: MockServer.shared.router)
+
+    XCTAssert(connect.authorized(application: application))
+
+    let result = try! await connect.capabilities(vehicle: vehicle)
+
+    expectation.fulfill()
+    XCTAssert(connect.authorized(application: application))
+    XCTAssertNotNil(result.response)
+    XCTAssertNotNil(result.capabilities)
+    assertCapabilities(result.capabilities!)
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  func testCapabilitiesNoAuthRequiredFailure() async {
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockGetCapabilitiesFailure(router: MockServer.shared.router)
+
+    XCTAssert(connect.authorized(application: application))
+
+    do {
+      _ = try await connect.capabilities(vehicle: vehicle)
+    } catch {
+      expectation.fulfill()
+      XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
+    }
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  func testCapabilitiesAuthRequiredAuthFailure() async {
+    connect.auths[application] = nil
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockPostLoginAuthFailure(router: MockServer.shared.router)
+
+    XCTAssertFalse(connect.authorized(application: application))
+
+    do {
+      _ = try await connect.capabilities(vehicle: vehicle)
+    } catch {
+      expectation.fulfill()
       XCTAssertFalse(connect.authorized(application: application))
-      
-      let result = try! await connect.capabilities(vehicle: vehicle)
-      
+      XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
+    }
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  // MARK: - Emobility Tests
+
+  func testEmobilityAuthRequiredSuccessful() async {
+    connect.auths[application] = nil
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
+    mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
+    mockNetworkRoutes.mockPostApiTokenSuccessful(router: MockServer.shared.router)
+    mockNetworkRoutes.mockGetEmobilityNotChargingSuccessful(router: MockServer.shared.router)
+
+    XCTAssertFalse(connect.authorized(application: application))
+
+    let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+
+    expectation.fulfill()
+    XCTAssertNotNil(result.response)
+    XCTAssertNotNil(result.emobility)
+    assertEmobilityWhenNotCharging(result.emobility!)
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  func testEmobilityNotChargingNoAuthRequiredSuccessful() async {
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockGetEmobilityNotChargingSuccessful(router: MockServer.shared.router)
+
+    XCTAssert(connect.authorized(application: application))
+
+    let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+
+    expectation.fulfill()
+    XCTAssert(connect.authorized(application: application))
+    XCTAssertNotNil(result.response)
+    XCTAssertNotNil(result.emobility)
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  func testEmobilityACTimerChargingNoAuthRequiredSuccessful() async {
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockGetEmobilityACTimerChargingSuccessful(router: MockServer.shared.router)
+
+    XCTAssert(connect.authorized(application: application))
+
+    let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+
+    expectation.fulfill()
+    XCTAssert(connect.authorized(application: application))
+    XCTAssertNotNil(result.response)
+    XCTAssertNotNil(result.emobility)
+    assertEmobilityWhenACTimerCharging(result.emobility!)
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  func testEmobilityACDirectChargingNoAuthRequiredSuccessful() async {
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockGetEmobilityACDirectChargingSuccessful(router: MockServer.shared.router)
+
+    XCTAssert(connect.authorized(application: application))
+
+    let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+
+    expectation.fulfill()
+    XCTAssert(connect.authorized(application: application))
+    XCTAssertNotNil(result.response)
+    XCTAssertNotNil(result.emobility)
+    assertEmobilityWhenACDirectCharging(result.emobility!)
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  func testEmobilityDCChargingNoAuthRequiredSuccessful() async {
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockGetEmobilityDCChargingSuccessful(router: MockServer.shared.router)
+
+    XCTAssert(connect.authorized(application: application))
+
+    let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+
+    expectation.fulfill()
+    XCTAssert(connect.authorized(application: application))
+    XCTAssertNotNil(result.response)
+    XCTAssertNotNil(result.emobility)
+    assertEmobilityWhenDCCharging(result.emobility!)
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  func testEmobilityNoAuthRequiredFailure() async {
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockGetEmobilityFailure(router: MockServer.shared.router)
+
+    XCTAssert(connect.authorized(application: application))
+
+    do {
+      _ = try await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+    } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
-      XCTAssertNotNil(result.response)
-      XCTAssertNotNil(result.capabilities)
-      assertCapabilities(result.capabilities!)
-  
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+      XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
-  
-    func testCapabilitiesNoAuthRequiredSuccessful() async {
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockGetCapabilitiesSuccessful(router: MockServer.shared.router)
-  
-      XCTAssert(connect.authorized(application: application))
-  
-      let result = try! await connect.capabilities(vehicle: vehicle)
-      
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
+  func testEmobilityAuthRequiredAuthFailure() async {
+    connect.auths[application] = nil
+    let expectation = expectation(description: "Network Expectation")
+
+    mockNetworkRoutes.mockPostLoginAuthFailure(router: MockServer.shared.router)
+
+    XCTAssertFalse(connect.authorized(application: application))
+
+    do {
+      _ = try await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+    } catch {
       expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
-      XCTAssertNotNil(result.response)
-      XCTAssertNotNil(result.capabilities)
-      assertCapabilities(result.capabilities!)
-      
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
-    }
-  
-    func testCapabilitiesNoAuthRequiredFailure() async {
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockGetCapabilitiesFailure(router: MockServer.shared.router)
-  
-      XCTAssert(connect.authorized(application: application))
-  
-      do {
-        _ = try await connect.capabilities(vehicle: vehicle)
-      } catch {
-        expectation.fulfill()
-        XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
-      }
-        
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
-    }
-  
-    func testCapabilitiesAuthRequiredAuthFailure() async {
-      connect.auths[application] = nil
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockPostLoginAuthFailure(router: MockServer.shared.router)
-  
       XCTAssertFalse(connect.authorized(application: application))
-  
-      do {
-        _ = try await connect.capabilities(vehicle: vehicle)
-      } catch {
-        expectation.fulfill()
-        XCTAssertFalse(connect.authorized(application: application))
-        XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
-      }
-      
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+      XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
     }
-  
-    // MARK: - Emobility Tests
-  
-    func testEmobilityAuthRequiredSuccessful() async {
-      connect.auths[application] = nil
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
-      mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
-      mockNetworkRoutes.mockPostApiTokenSuccessful(router: MockServer.shared.router)
-      mockNetworkRoutes.mockGetEmobilityNotChargingSuccessful(router: MockServer.shared.router)
-  
-      XCTAssertFalse(connect.authorized(application: application))
-      
-      let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
-      
-      expectation.fulfill()
-      XCTAssertNotNil(result.response)
-      XCTAssertNotNil(result.emobility)
-      assertEmobilityWhenNotCharging(result.emobility!)
-  
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
-    }
-  
-    func testEmobilityNotChargingNoAuthRequiredSuccessful() async {
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockGetEmobilityNotChargingSuccessful(router: MockServer.shared.router)
-  
-      XCTAssert(connect.authorized(application: application))
-  
-      let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
-      
-      expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
-      XCTAssertNotNil(result.response)
-      XCTAssertNotNil(result.emobility)
-        
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
-    }
-  
-    func testEmobilityACTimerChargingNoAuthRequiredSuccessful() async {
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockGetEmobilityACTimerChargingSuccessful(router: MockServer.shared.router)
-  
-      XCTAssert(connect.authorized(application: application))
-  
-      let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
 
-      expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
-      XCTAssertNotNil(result.response)
-      XCTAssertNotNil(result.emobility)
-      assertEmobilityWhenACTimerCharging(result.emobility!)
-        
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
-    }
-  
-    func testEmobilityACDirectChargingNoAuthRequiredSuccessful() async {
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockGetEmobilityACDirectChargingSuccessful(router: MockServer.shared.router)
-  
-      XCTAssert(connect.authorized(application: application))
-  
-      let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
 
-      expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
-      XCTAssertNotNil(result.response)
-      XCTAssertNotNil(result.emobility)
-      assertEmobilityWhenACDirectCharging(result.emobility!)
-        
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
-    }
-  
-    func testEmobilityDCChargingNoAuthRequiredSuccessful() async {
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockGetEmobilityDCChargingSuccessful(router: MockServer.shared.router)
-  
-      XCTAssert(connect.authorized(application: application))
-  
-      let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
-
-      expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
-      XCTAssertNotNil(result.response)
-      XCTAssertNotNil(result.emobility)
-      assertEmobilityWhenDCCharging(result.emobility!)
-  
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
-    }
-  
-    func testEmobilityNoAuthRequiredFailure() async {
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockGetEmobilityFailure(router: MockServer.shared.router)
-  
-      XCTAssert(connect.authorized(application: application))
-  
-      do {
-        _ = try await connect.emobility(vehicle: vehicle, capabilities: capabilites)
-      } catch {
-        expectation.fulfill()
-        XCTAssert(connect.authorized(application: application))
-        XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
-      }
-        
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
-    }
-  
-    func testEmobilityAuthRequiredAuthFailure() async {
-      connect.auths[application] = nil
-      let expectation = expectation(description: "Network Expectation")
-
-      mockNetworkRoutes.mockPostLoginAuthFailure(router: MockServer.shared.router)
-
-      XCTAssertFalse(connect.authorized(application: application))
-
-      do {
-        _ = try await connect.emobility(vehicle: vehicle, capabilities: capabilites)
-      } catch {
-        expectation.fulfill()
-        XCTAssertFalse(connect.authorized(application: application))
-        XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
-      }
-      
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
-    }
-  
   // MARK: - Honk and Flash Tests
-  
+
   func testFlashAuthRequiredSuccessful() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    
+
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostFlashSuccessful(router: MockServer.shared.router)
-    
+
     XCTAssertFalse(connect.authorized(application: application))
-    
+
     let result = try! await connect.flash(vehicle: vehicle)
-    
+
     expectation.fulfill()
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAccepted(result.remoteCommandAccepted!)
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testFlashAuthRequiredFailure() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    
+
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostFlashFailure(router: MockServer.shared.router)
-    
+
     XCTAssertFalse(connect.authorized(application: application))
-    
+
     do {
       _ = try await connect.flash(vehicle: vehicle)
     } catch {
@@ -408,42 +408,42 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
       XCTAssert(connect.authorized(application: application))
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testHonkAndFlashAuthRequiredSuccessful() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    
+
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostHonkAndFlashSuccessful(router: MockServer.shared.router)
-    
+
     XCTAssertFalse(connect.authorized(application: application))
-    
+
     let result = try! await connect.flash(vehicle: vehicle, andHonk: true)
-    
+
     expectation.fulfill()
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAccepted(result.remoteCommandAccepted!)
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testHonkAndFlashAuthRequiredFailure() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    
+
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostHonkAndFlashFailure(router: MockServer.shared.router)
-    
+
     XCTAssertFalse(connect.authorized(application: application))
-    
+
     do {
       _ = try await connect.flash(vehicle: vehicle, andHonk: true)
     } catch {
@@ -451,27 +451,27 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
       XCTAssert(connect.authorized(application: application))
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
-  
+
+
   // MARK: - Private functions
-  
+
   private func assertSummary(_ summary: Summary) {
     XCTAssertEqual("Taycan 4S", summary.modelDescription)
     XCTAssertEqual("211-D-12345", summary.nickName)
   }
-  
+
   private func assertPosition(_ position: Position) {
     XCTAssertEqual(68, position.heading)
     let carCoordinate = position.carCoordinate
-    
+
     XCTAssertEqual("WGS84", carCoordinate.geoCoordinateSystem)
     XCTAssertEqual(53.395367, carCoordinate.latitude)
     XCTAssertEqual(-6.389296, carCoordinate.longitude)
   }
-  
+
   private func assertCapabilities(_ capabilities: Capabilities) {
     XCTAssertNotNil(capabilities.heatingCapabilities)
     XCTAssertNotNil(capabilities.onlineRemoteUpdateStatus)
@@ -487,14 +487,14 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertEqual("RIGHT", capabilities.steeringWheelPosition)
     XCTAssertTrue(capabilities.hasHonkAndFlash)
   }
-  
+
   private func assertEmobilityWhenNotCharging(_ emobility: Emobility) {
     XCTAssertNotNil(emobility.batteryChargeStatus)
     XCTAssertNotNil(emobility.directCharge)
     XCTAssertNotNil(emobility.directClimatisation)
-    
+
     let batteryChargeStatus = emobility.batteryChargeStatus
-    
+
     XCTAssertEqual("DISCONNECTED", batteryChargeStatus.plugState)
     XCTAssertEqual("UNLOCKED", batteryChargeStatus.lockState)
     XCTAssertEqual("OFF", batteryChargeStatus.chargingState)
@@ -505,7 +505,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertEqual("OFF", batteryChargeStatus.chargingMode)
     XCTAssertEqual(56, batteryChargeStatus.stateOfChargeInPercentage)
     XCTAssertNil(batteryChargeStatus.remainingChargeTimeUntil100PercentInMinutes)
-    
+
     XCTAssertNotNil(batteryChargeStatus.remainingERange)
     let remainingERange = batteryChargeStatus.remainingERange
     XCTAssertEqual(191, remainingERange.value)
@@ -514,43 +514,43 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertEqual("KILOMETER", remainingERange.originalUnit)
     XCTAssertEqual(191, remainingERange.valueInKilometers)
     XCTAssertEqual("GRAY_SLICE_UNIT_KILOMETER", remainingERange.unitTranslationKey)
-    
+
     XCTAssertNil(batteryChargeStatus.remainingCRange)
     XCTAssertEqual("2021-02-19T01:09", batteryChargeStatus.chargingTargetDateTime)
     XCTAssertNil(batteryChargeStatus.status)
-    
+
     XCTAssertNotNil(batteryChargeStatus.chargeRate)
     let chargeRate = batteryChargeStatus.chargeRate
     XCTAssertEqual(0, chargeRate.value)
     XCTAssertEqual("KM_PER_MIN", chargeRate.unit)
     XCTAssertEqual(0, chargeRate.valueInKmPerHour)
     XCTAssertEqual("EC.COMMON.UNIT.KM_PER_MIN", chargeRate.unitTranslationKey)
-    
+
     XCTAssertEqual(0, batteryChargeStatus.chargingPower)
     XCTAssertFalse(batteryChargeStatus.chargingInDCMode)
-    
+
     let directCharge = emobility.directCharge
     XCTAssertFalse(directCharge.disabled)
     XCTAssertFalse(directCharge.isActive)
-    
+
     let directClimatisation = emobility.directClimatisation
     XCTAssertEqual("OFF", directClimatisation.climatisationState)
     XCTAssertNil(directClimatisation.remainingClimatisationTime)
-    
+
     XCTAssertEqual("NOT_CHARGING", emobility.chargingStatus)
-    
+
     XCTAssertNotNil(emobility.chargingProfiles)
     let chargingProfiles = emobility.chargingProfiles
     XCTAssertEqual(4, chargingProfiles.currentProfileId)
     XCTAssertNotNil(chargingProfiles.profiles)
     XCTAssertEqual(2, chargingProfiles.profiles.count)
-    
+
     let chargingProfile1 = chargingProfiles.profiles[0]
     XCTAssertNotNil(chargingProfile1)
     XCTAssertEqual(4, chargingProfile1.profileId)
     XCTAssertEqual("Allgemein", chargingProfile1.profileName)
     XCTAssertTrue(chargingProfile1.profileActive)
-    
+
     XCTAssertNotNil(chargingProfile1.chargingOptions)
     let chargingOptionsForChargingProfile1 = chargingProfile1.chargingOptions
     XCTAssertEqual(100, chargingOptionsForChargingProfile1.minimumChargeLevel)
@@ -558,18 +558,18 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(chargingOptionsForChargingProfile1.preferredChargingEnabled)
     XCTAssertEqual("00:00", chargingOptionsForChargingProfile1.preferredChargingTimeStart)
     XCTAssertEqual("06:00", chargingOptionsForChargingProfile1.preferredChargingTimeEnd)
-    
+
     XCTAssertNotNil(chargingProfile1.position)
     let positionForChargingProfile1 = chargingProfile1.position
     XCTAssertEqual(0, positionForChargingProfile1.latitude)
     XCTAssertEqual(0, positionForChargingProfile1.longitude)
-    
+
     let chargingProfile2 = chargingProfiles.profiles[1]
     XCTAssertNotNil(chargingProfile2)
     XCTAssertEqual(5, chargingProfile2.profileId)
     XCTAssertEqual("HOME", chargingProfile2.profileName)
     XCTAssertTrue(chargingProfile2.profileActive)
-    
+
     XCTAssertNotNil(chargingProfile2.chargingOptions)
     let chargingOptionsForChargingProfile2 = chargingProfile2.chargingOptions
     XCTAssertEqual(25, chargingOptionsForChargingProfile2.minimumChargeLevel)
@@ -577,17 +577,17 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(chargingOptionsForChargingProfile2.preferredChargingEnabled)
     XCTAssertEqual("23:00", chargingOptionsForChargingProfile2.preferredChargingTimeStart)
     XCTAssertEqual("08:00", chargingOptionsForChargingProfile2.preferredChargingTimeEnd)
-    
+
     XCTAssertNotNil(chargingProfile2.position)
     let positionForChargingProfile2 = chargingProfile2.position
     XCTAssertEqual(53.365771, positionForChargingProfile2.latitude)
     XCTAssertEqual(-6.330550, positionForChargingProfile2.longitude)
-    
+
     XCTAssertNil(emobility.climateTimer)
-    
+
     XCTAssertNotNil(emobility.timers)
     XCTAssertEqual(1, emobility.timers!.count)
-    
+
     let timer = emobility.timers![0]
     XCTAssertNotNil(timer)
     XCTAssertEqual("1", timer.timerID)
@@ -601,7 +601,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(timer.chargeOption)
     XCTAssertEqual(80, timer.targetChargeLevel)
     XCTAssertFalse(timer.climatisationTimer)
-    
+
     XCTAssertNotNil(timer.weekDays)
     let weekdays = timer.weekDays
     XCTAssertTrue(weekdays.SUNDAY)
@@ -612,14 +612,14 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(weekdays.FRIDAY)
     XCTAssertTrue(weekdays.SATURDAY)
   }
-  
+
   private func assertEmobilityWhenACTimerCharging(_ emobility: Emobility) {
     XCTAssertNotNil(emobility.batteryChargeStatus)
     XCTAssertNotNil(emobility.directCharge)
     XCTAssertNotNil(emobility.directClimatisation)
-    
+
     let batteryChargeStatus = emobility.batteryChargeStatus
-    
+
     XCTAssertEqual("CONNECTED", batteryChargeStatus.plugState)
     XCTAssertEqual("LOCKED", batteryChargeStatus.lockState)
     XCTAssertEqual("CHARGING", batteryChargeStatus.chargingState)
@@ -630,7 +630,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertEqual("AC", batteryChargeStatus.chargingMode)
     XCTAssertEqual(56, batteryChargeStatus.stateOfChargeInPercentage)
     XCTAssertEqual(260, batteryChargeStatus.remainingChargeTimeUntil100PercentInMinutes)
-    
+
     XCTAssertNotNil(batteryChargeStatus.remainingERange)
     let remainingERange = batteryChargeStatus.remainingERange
     XCTAssertEqual(191, remainingERange.value)
@@ -639,43 +639,43 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertEqual("KILOMETER", remainingERange.originalUnit)
     XCTAssertEqual(191, remainingERange.valueInKilometers)
     XCTAssertEqual("GRAY_SLICE_UNIT_KILOMETER", remainingERange.unitTranslationKey)
-    
+
     XCTAssertNil(batteryChargeStatus.remainingCRange)
     XCTAssertEqual("2021-02-19T01:09", batteryChargeStatus.chargingTargetDateTime)
     XCTAssertNil(batteryChargeStatus.status)
-    
+
     XCTAssertNotNil(batteryChargeStatus.chargeRate)
     let chargeRate = batteryChargeStatus.chargeRate
     XCTAssertEqual(0.5, chargeRate.value)
     XCTAssertEqual("KM_PER_MIN", chargeRate.unit)
     XCTAssertEqual(30, chargeRate.valueInKmPerHour)
     XCTAssertEqual("EC.COMMON.UNIT.KM_PER_MIN", chargeRate.unitTranslationKey)
-    
+
     XCTAssertEqual(6.58, batteryChargeStatus.chargingPower)
     XCTAssertFalse(batteryChargeStatus.chargingInDCMode)
-    
+
     let directCharge = emobility.directCharge
     XCTAssertFalse(directCharge.disabled)
     XCTAssertFalse(directCharge.isActive)
-    
+
     let directClimatisation = emobility.directClimatisation
     XCTAssertEqual("OFF", directClimatisation.climatisationState)
     XCTAssertNil(directClimatisation.remainingClimatisationTime)
-    
+
     XCTAssertEqual("ONGOING_TIMER", emobility.chargingStatus)
-    
+
     XCTAssertNotNil(emobility.chargingProfiles)
     let chargingProfiles = emobility.chargingProfiles
     XCTAssertEqual(4, chargingProfiles.currentProfileId)
     XCTAssertNotNil(chargingProfiles.profiles)
     XCTAssertEqual(2, chargingProfiles.profiles.count)
-    
+
     let chargingProfile1 = chargingProfiles.profiles[0]
     XCTAssertNotNil(chargingProfile1)
     XCTAssertEqual(4, chargingProfile1.profileId)
     XCTAssertEqual("Allgemein", chargingProfile1.profileName)
     XCTAssertTrue(chargingProfile1.profileActive)
-    
+
     XCTAssertNotNil(chargingProfile1.chargingOptions)
     let chargingOptionsForChargingProfile1 = chargingProfile1.chargingOptions
     XCTAssertEqual(100, chargingOptionsForChargingProfile1.minimumChargeLevel)
@@ -683,18 +683,18 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(chargingOptionsForChargingProfile1.preferredChargingEnabled)
     XCTAssertEqual("00:00", chargingOptionsForChargingProfile1.preferredChargingTimeStart)
     XCTAssertEqual("06:00", chargingOptionsForChargingProfile1.preferredChargingTimeEnd)
-    
+
     XCTAssertNotNil(chargingProfile1.position)
     let positionForChargingProfile1 = chargingProfile1.position
     XCTAssertEqual(0, positionForChargingProfile1.latitude)
     XCTAssertEqual(0, positionForChargingProfile1.longitude)
-    
+
     let chargingProfile2 = chargingProfiles.profiles[1]
     XCTAssertNotNil(chargingProfile2)
     XCTAssertEqual(5, chargingProfile2.profileId)
     XCTAssertEqual("HOME", chargingProfile2.profileName)
     XCTAssertTrue(chargingProfile2.profileActive)
-    
+
     XCTAssertNotNil(chargingProfile2.chargingOptions)
     let chargingOptionsForChargingProfile2 = chargingProfile2.chargingOptions
     XCTAssertEqual(25, chargingOptionsForChargingProfile2.minimumChargeLevel)
@@ -702,17 +702,17 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(chargingOptionsForChargingProfile2.preferredChargingEnabled)
     XCTAssertEqual("23:00", chargingOptionsForChargingProfile2.preferredChargingTimeStart)
     XCTAssertEqual("08:00", chargingOptionsForChargingProfile2.preferredChargingTimeEnd)
-    
+
     XCTAssertNotNil(chargingProfile2.position)
     let positionForChargingProfile2 = chargingProfile2.position
     XCTAssertEqual(53.365771, positionForChargingProfile2.latitude)
     XCTAssertEqual(-6.330550, positionForChargingProfile2.longitude)
-    
+
     XCTAssertNil(emobility.climateTimer)
-    
+
     XCTAssertNotNil(emobility.timers)
     XCTAssertEqual(1, emobility.timers!.count)
-    
+
     let timer = emobility.timers![0]
     XCTAssertNotNil(timer)
     XCTAssertEqual("1", timer.timerID)
@@ -726,7 +726,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(timer.chargeOption)
     XCTAssertEqual(80, timer.targetChargeLevel)
     XCTAssertFalse(timer.climatisationTimer)
-    
+
     XCTAssertNotNil(timer.weekDays)
     let weekdays = timer.weekDays
     XCTAssertTrue(weekdays.SUNDAY)
@@ -737,14 +737,14 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(weekdays.FRIDAY)
     XCTAssertTrue(weekdays.SATURDAY)
   }
-  
+
   private func assertEmobilityWhenACDirectCharging(_ emobility: Emobility) {
     XCTAssertNotNil(emobility.batteryChargeStatus)
     XCTAssertNotNil(emobility.directCharge)
     XCTAssertNotNil(emobility.directClimatisation)
-    
+
     let batteryChargeStatus = emobility.batteryChargeStatus
-    
+
     XCTAssertEqual("CONNECTED", batteryChargeStatus.plugState)
     XCTAssertEqual("LOCKED", batteryChargeStatus.lockState)
     XCTAssertEqual("CHARGING", batteryChargeStatus.chargingState)
@@ -755,7 +755,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertEqual("AC", batteryChargeStatus.chargingMode)
     XCTAssertEqual(56, batteryChargeStatus.stateOfChargeInPercentage)
     XCTAssertEqual(260, batteryChargeStatus.remainingChargeTimeUntil100PercentInMinutes)
-    
+
     XCTAssertNotNil(batteryChargeStatus.remainingERange)
     let remainingERange = batteryChargeStatus.remainingERange
     XCTAssertEqual(191, remainingERange.value)
@@ -764,43 +764,43 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertEqual("KILOMETER", remainingERange.originalUnit)
     XCTAssertEqual(191, remainingERange.valueInKilometers)
     XCTAssertEqual("GRAY_SLICE_UNIT_KILOMETER", remainingERange.unitTranslationKey)
-    
+
     XCTAssertNil(batteryChargeStatus.remainingCRange)
     XCTAssertEqual("2021-02-19T01:09", batteryChargeStatus.chargingTargetDateTime)
     XCTAssertNil(batteryChargeStatus.status)
-    
+
     XCTAssertNotNil(batteryChargeStatus.chargeRate)
     let chargeRate = batteryChargeStatus.chargeRate
     XCTAssertEqual(1.1, chargeRate.value)
     XCTAssertEqual("KM_PER_MIN", chargeRate.unit)
     XCTAssertEqual(66, chargeRate.valueInKmPerHour)
     XCTAssertEqual("EC.COMMON.UNIT.KM_PER_MIN", chargeRate.unitTranslationKey)
-    
+
     XCTAssertEqual(20.71, batteryChargeStatus.chargingPower)
     XCTAssertFalse(batteryChargeStatus.chargingInDCMode)
-    
+
     let directCharge = emobility.directCharge
     XCTAssertFalse(directCharge.disabled)
     XCTAssertTrue(directCharge.isActive)
-    
+
     let directClimatisation = emobility.directClimatisation
     XCTAssertEqual("OFF", directClimatisation.climatisationState)
     XCTAssertNil(directClimatisation.remainingClimatisationTime)
-    
+
     XCTAssertEqual("INSTANT_CHARGING", emobility.chargingStatus)
-    
+
     XCTAssertNotNil(emobility.chargingProfiles)
     let chargingProfiles = emobility.chargingProfiles
     XCTAssertEqual(4, chargingProfiles.currentProfileId)
     XCTAssertNotNil(chargingProfiles.profiles)
     XCTAssertEqual(2, chargingProfiles.profiles.count)
-    
+
     let chargingProfile1 = chargingProfiles.profiles[0]
     XCTAssertNotNil(chargingProfile1)
     XCTAssertEqual(4, chargingProfile1.profileId)
     XCTAssertEqual("Allgemein", chargingProfile1.profileName)
     XCTAssertTrue(chargingProfile1.profileActive)
-    
+
     XCTAssertNotNil(chargingProfile1.chargingOptions)
     let chargingOptionsForChargingProfile1 = chargingProfile1.chargingOptions
     XCTAssertEqual(100, chargingOptionsForChargingProfile1.minimumChargeLevel)
@@ -808,18 +808,18 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(chargingOptionsForChargingProfile1.preferredChargingEnabled)
     XCTAssertEqual("00:00", chargingOptionsForChargingProfile1.preferredChargingTimeStart)
     XCTAssertEqual("06:00", chargingOptionsForChargingProfile1.preferredChargingTimeEnd)
-    
+
     XCTAssertNotNil(chargingProfile1.position)
     let positionForChargingProfile1 = chargingProfile1.position
     XCTAssertEqual(0, positionForChargingProfile1.latitude)
     XCTAssertEqual(0, positionForChargingProfile1.longitude)
-    
+
     let chargingProfile2 = chargingProfiles.profiles[1]
     XCTAssertNotNil(chargingProfile2)
     XCTAssertEqual(5, chargingProfile2.profileId)
     XCTAssertEqual("HOME", chargingProfile2.profileName)
     XCTAssertTrue(chargingProfile2.profileActive)
-    
+
     XCTAssertNotNil(chargingProfile2.chargingOptions)
     let chargingOptionsForChargingProfile2 = chargingProfile2.chargingOptions
     XCTAssertEqual(25, chargingOptionsForChargingProfile2.minimumChargeLevel)
@@ -827,17 +827,17 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(chargingOptionsForChargingProfile2.preferredChargingEnabled)
     XCTAssertEqual("23:00", chargingOptionsForChargingProfile2.preferredChargingTimeStart)
     XCTAssertEqual("08:00", chargingOptionsForChargingProfile2.preferredChargingTimeEnd)
-    
+
     XCTAssertNotNil(chargingProfile2.position)
     let positionForChargingProfile2 = chargingProfile2.position
     XCTAssertEqual(53.365771, positionForChargingProfile2.latitude)
     XCTAssertEqual(-6.330550, positionForChargingProfile2.longitude)
-    
+
     XCTAssertNil(emobility.climateTimer)
-    
+
     XCTAssertNotNil(emobility.timers)
     XCTAssertEqual(1, emobility.timers!.count)
-    
+
     let timer = emobility.timers![0]
     XCTAssertNotNil(timer)
     XCTAssertEqual("1", timer.timerID)
@@ -851,7 +851,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(timer.chargeOption)
     XCTAssertEqual(80, timer.targetChargeLevel)
     XCTAssertFalse(timer.climatisationTimer)
-    
+
     XCTAssertNotNil(timer.weekDays)
     let weekdays = timer.weekDays
     XCTAssertTrue(weekdays.SUNDAY)
@@ -862,14 +862,14 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(weekdays.FRIDAY)
     XCTAssertTrue(weekdays.SATURDAY)
   }
-  
+
   private func assertEmobilityWhenDCCharging(_ emobility: Emobility) {
     XCTAssertNotNil(emobility.batteryChargeStatus)
     XCTAssertNotNil(emobility.directCharge)
     XCTAssertNotNil(emobility.directClimatisation)
-    
+
     let batteryChargeStatus = emobility.batteryChargeStatus
-    
+
     XCTAssertEqual("CONNECTED", batteryChargeStatus.plugState)
     XCTAssertEqual("LOCKED", batteryChargeStatus.lockState)
     XCTAssertEqual("CHARGING", batteryChargeStatus.chargingState)
@@ -880,7 +880,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertEqual("DC", batteryChargeStatus.chargingMode)
     XCTAssertEqual(56, batteryChargeStatus.stateOfChargeInPercentage)
     XCTAssertEqual(122, batteryChargeStatus.remainingChargeTimeUntil100PercentInMinutes)
-    
+
     XCTAssertNotNil(batteryChargeStatus.remainingERange)
     let remainingERange = batteryChargeStatus.remainingERange
     XCTAssertEqual(191, remainingERange.value)
@@ -889,43 +889,43 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertEqual("KILOMETER", remainingERange.originalUnit)
     XCTAssertEqual(191, remainingERange.valueInKilometers)
     XCTAssertEqual("GRAY_SLICE_UNIT_KILOMETER", remainingERange.unitTranslationKey)
-    
+
     XCTAssertNil(batteryChargeStatus.remainingCRange)
     XCTAssertEqual("2021-02-19T01:09", batteryChargeStatus.chargingTargetDateTime)
     XCTAssertNil(batteryChargeStatus.status)
-    
+
     XCTAssertNotNil(batteryChargeStatus.chargeRate)
     let chargeRate = batteryChargeStatus.chargeRate
     XCTAssertEqual(3.0, chargeRate.value)
     XCTAssertEqual("KM_PER_MIN", chargeRate.unit)
     XCTAssertEqual(180, chargeRate.valueInKmPerHour)
     XCTAssertEqual("EC.COMMON.UNIT.KM_PER_MIN", chargeRate.unitTranslationKey)
-    
+
     XCTAssertEqual(48.56, batteryChargeStatus.chargingPower)
     XCTAssertTrue(batteryChargeStatus.chargingInDCMode)
-    
+
     let directCharge = emobility.directCharge
     XCTAssertTrue(directCharge.disabled)
     XCTAssertFalse(directCharge.isActive)
-    
+
     let directClimatisation = emobility.directClimatisation
     XCTAssertEqual("OFF", directClimatisation.climatisationState)
     XCTAssertNil(directClimatisation.remainingClimatisationTime)
-    
+
     XCTAssertEqual("INSTANT_CHARGING", emobility.chargingStatus)
-    
+
     XCTAssertNotNil(emobility.chargingProfiles)
     let chargingProfiles = emobility.chargingProfiles
     XCTAssertEqual(4, chargingProfiles.currentProfileId)
     XCTAssertNotNil(chargingProfiles.profiles)
     XCTAssertEqual(2, chargingProfiles.profiles.count)
-    
+
     let chargingProfile1 = chargingProfiles.profiles[0]
     XCTAssertNotNil(chargingProfile1)
     XCTAssertEqual(4, chargingProfile1.profileId)
     XCTAssertEqual("Allgemein", chargingProfile1.profileName)
     XCTAssertTrue(chargingProfile1.profileActive)
-    
+
     XCTAssertNotNil(chargingProfile1.chargingOptions)
     let chargingOptionsForChargingProfile1 = chargingProfile1.chargingOptions
     XCTAssertEqual(100, chargingOptionsForChargingProfile1.minimumChargeLevel)
@@ -933,18 +933,18 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(chargingOptionsForChargingProfile1.preferredChargingEnabled)
     XCTAssertEqual("00:00", chargingOptionsForChargingProfile1.preferredChargingTimeStart)
     XCTAssertEqual("06:00", chargingOptionsForChargingProfile1.preferredChargingTimeEnd)
-    
+
     XCTAssertNotNil(chargingProfile1.position)
     let positionForChargingProfile1 = chargingProfile1.position
     XCTAssertEqual(0, positionForChargingProfile1.latitude)
     XCTAssertEqual(0, positionForChargingProfile1.longitude)
-    
+
     let chargingProfile2 = chargingProfiles.profiles[1]
     XCTAssertNotNil(chargingProfile2)
     XCTAssertEqual(5, chargingProfile2.profileId)
     XCTAssertEqual("HOME", chargingProfile2.profileName)
     XCTAssertTrue(chargingProfile2.profileActive)
-    
+
     XCTAssertNotNil(chargingProfile2.chargingOptions)
     let chargingOptionsForChargingProfile2 = chargingProfile2.chargingOptions
     XCTAssertEqual(25, chargingOptionsForChargingProfile2.minimumChargeLevel)
@@ -952,17 +952,17 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(chargingOptionsForChargingProfile2.preferredChargingEnabled)
     XCTAssertEqual("23:00", chargingOptionsForChargingProfile2.preferredChargingTimeStart)
     XCTAssertEqual("08:00", chargingOptionsForChargingProfile2.preferredChargingTimeEnd)
-    
+
     XCTAssertNotNil(chargingProfile2.position)
     let positionForChargingProfile2 = chargingProfile2.position
     XCTAssertEqual(53.365771, positionForChargingProfile2.latitude)
     XCTAssertEqual(-6.330550, positionForChargingProfile2.longitude)
-    
+
     XCTAssertNil(emobility.climateTimer)
-    
+
     XCTAssertNotNil(emobility.timers)
     XCTAssertEqual(1, emobility.timers!.count)
-    
+
     let timer = emobility.timers![0]
     XCTAssertNotNil(timer)
     XCTAssertEqual("1", timer.timerID)
@@ -976,7 +976,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(timer.chargeOption)
     XCTAssertEqual(80, timer.targetChargeLevel)
     XCTAssertFalse(timer.climatisationTimer)
-    
+
     XCTAssertNotNil(timer.weekDays)
     let weekdays = timer.weekDays
     XCTAssertTrue(weekdays.SUNDAY)
@@ -987,7 +987,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(weekdays.FRIDAY)
     XCTAssertTrue(weekdays.SATURDAY)
   }
-  
+
   private func assertRemoteCommandAccepted(_ remoteCommandAccepted: RemoteCommandAccepted) {
     XCTAssertNotNil(remoteCommandAccepted)
     XCTAssertEqual("123456789", remoteCommandAccepted.id)

--- a/Tests/PorscheConnectTests/PorscheConnect+PortalTests.swift
+++ b/Tests/PorscheConnectTests/PorscheConnect+PortalTests.swift
@@ -2,99 +2,99 @@ import XCTest
 @testable import PorscheConnect
 
 final class PorscheConnectPortalTests: BaseMockNetworkTestCase {
-  
+
   // MARK: - Properties
-  
+
   var connect: PorscheConnect!
   let mockNetworkRoutes = MockNetworkRoutes()
   let application: Application = .api
-  
+
   // MARK: - Lifecycle
-  
+
   override func setUp() {
     super.setUp()
     connect = PorscheConnect(username: "homer.simpson@icloud.example", password: "Duh!", environment: .test)
     connect.auths[application] = kTestPorschePortalAuth
   }
-  
+
   // MARK: - Tests
-  
+
   func testVehiclesAuthRequiredSuccessful() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    
+
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: MockServer.shared.router)
     mockNetworkRoutes.mockGetVehiclesSuccessful(router: MockServer.shared.router)
-    
+
     XCTAssertFalse(connect.authorized(application: application))
-    
+
     let result = try! await connect.vehicles()
-    
+
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.vehicles)
     XCTAssertEqual(1, result.vehicles!.count)
     assertVehicle(result.vehicles!.first!)
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testVehiclesNoAuthRequiredSuccessful() async {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetVehiclesSuccessful(router: MockServer.shared.router)
-    
+
     XCTAssert(connect.authorized(application: application))
-    
+
     let result = try! await connect.vehicles()
-    
+
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.vehicles)
     XCTAssertEqual(1, result.vehicles!.count)
     assertVehicle(result.vehicles!.first!)
-        
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
+
   func testVehiclesNoAuthRequiredFailure() async {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetVehiclesFailure(router: MockServer.shared.router)
-    
+
     XCTAssert(connect.authorized(application: application))
-    
+
     do {
-     _  = try await connect.vehicles()
+      _  = try await connect.vehicles()
     } catch {
       expectation.fulfill()
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
-    
+
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
-  
-    func testVehiclesAuthRequiredAuthFailure() async {
-      connect.auths[application] = nil
-      let expectation = expectation(description: "Network Expectation")
-      mockNetworkRoutes.mockPostLoginAuthFailure(router: MockServer.shared.router)
-      
-      XCTAssertFalse(connect.authorized(application: application))
-      
-      do {
-        _  = try await connect.vehicles()
-      } catch {
-        expectation.fulfill()
-        XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
-      }
-  
-      await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+
+  func testVehiclesAuthRequiredAuthFailure() async {
+    connect.auths[application] = nil
+    let expectation = expectation(description: "Network Expectation")
+    mockNetworkRoutes.mockPostLoginAuthFailure(router: MockServer.shared.router)
+
+    XCTAssertFalse(connect.authorized(application: application))
+
+    do {
+      _  = try await connect.vehicles()
+    } catch {
+      expectation.fulfill()
+      XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
     }
-  
+
+    await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
+  }
+
   // MARK: - Private functions
-  
+
   private func assertVehicle(_ vehicle: Vehicle) {
     XCTAssertEqual("VIN12345", vehicle.vin)
     XCTAssertEqual("Porsche Taycan 4S", vehicle.modelDescription)

--- a/Tests/PorscheConnectTests/PorscheConnectTests.swift
+++ b/Tests/PorscheConnectTests/PorscheConnectTests.swift
@@ -2,21 +2,21 @@ import XCTest
 @testable import PorscheConnect
 
 final class PorscheConnectTests: BaseMockNetworkTestCase {
-  
+
   // MARK: - Properties
-  
+
   var connect: PorscheConnect!
   let mockNetworkRoutes = MockNetworkRoutes()
-  
+
   // MARK: - Lifecycle
-  
+
   override func setUp() {
     super.setUp()
     connect = PorscheConnect(username: "homer.simpson@icloud.example", password: "Duh!", environment: .test)
   }
-  
+
   // MARK: - Tests
-  
+
   func testConstruction() {
     XCTAssertNotNil(connect)
     XCTAssertEqual(Environment.test, connect.environment)
@@ -25,7 +25,7 @@ final class PorscheConnectTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: .api))
     XCTAssertFalse(connect.authorized(application: .carControl))
   }
-  
+
   func testEnvironmentProduction() {
     let environment = Environment.production
     XCTAssertNotNil(environment)
@@ -33,7 +33,7 @@ final class PorscheConnectTests: BaseMockNetworkTestCase {
     XCTAssertEqual("de", environment.languageCode)
     XCTAssertEqual("de", environment.countryCode)
   }
-  
+
   func testEnvironmentTest() {
     let environment = Environment.test
     XCTAssertNotNil(environment)
@@ -41,17 +41,17 @@ final class PorscheConnectTests: BaseMockNetworkTestCase {
     XCTAssertEqual("en", environment.languageCode)
     XCTAssertEqual("ie", environment.countryCode)
   }
-  
+
   func testApplicationClientIdPortal() {
     let application = Application.api
     XCTAssertEqual("4mPO3OE5Srjb1iaUGWsbqKBvvesya8oA", application.clientId)
   }
-  
+
   func testApplicationClientIdCarControl() {
     let application = Application.carControl
     XCTAssertEqual("Ux8WmyzsOAGGmvmWnW7GLEjIILHEztAs", application.clientId)
   }
-  
+
   func testAuthLoggerIsDefined() {
     XCTAssertNotNil(AuthLogger)
   }


### PR DESCRIPTION
This removes all trailing whitespace and standardizes any scope block indentations.