### PR TITLE
Allow Environment to be configured with custom values.

### DIFF
--- a/Sources/PorscheConnect/Environment.swift
+++ b/Sources/PorscheConnect/Environment.swift
@@ -8,8 +8,10 @@ public struct Environment: Hashable {
   public let languageCode: LanguageCode
   public let regionCode: String
 
-  static public let germany = Environment(countryCode: .germany, languageCode: .german, regionCode: "de/de_DE")
-  static let test = Environment(countryCode: .ireland, languageCode: .english, regionCode: "ie/en_IE")
+  static public let germany = Environment(
+    countryCode: .germany, languageCode: .german, regionCode: "de/de_DE")
+  static let test = Environment(
+    countryCode: .ireland, languageCode: .english, regionCode: "ie/en_IE")
 }
 
 public enum CountryCode: String, Equatable {

--- a/Sources/PorscheConnect/Environment.swift
+++ b/Sources/PorscheConnect/Environment.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// The locale from which all API calls should be made.
+///
+/// The environment affects the units and localization of API responses.
+public struct Environment: Hashable {
+  public let countryCode: CountryCode
+  public let languageCode: LanguageCode
+  public let regionCode: String
+
+  static public let germany = Environment(countryCode: .germany, languageCode: .german, regionCode: "de/de_DE")
+  static let test = Environment(countryCode: .ireland, languageCode: .english, regionCode: "ie/en_IE")
+}
+
+public enum CountryCode: String, Equatable {
+  case germany = "de"
+  case ireland = "ie"
+  case unitedStates = "us"
+}
+
+public enum LanguageCode: String {
+  case english = "en"
+  case german = "de"
+}

--- a/Sources/PorscheConnect/Environment.swift
+++ b/Sources/PorscheConnect/Environment.swift
@@ -3,7 +3,7 @@ import Foundation
 /// The locale from which all API calls should be made.
 ///
 /// The environment affects the units and localization of API responses.
-public struct Environment: Hashable {
+public struct Environment: Equatable {
   public let countryCode: CountryCode
   public let languageCode: LanguageCode
   public let regionCode: String
@@ -14,7 +14,7 @@ public struct Environment: Hashable {
     countryCode: .ireland, languageCode: .english, regionCode: "ie/en_IE")
 }
 
-public enum CountryCode: String, Equatable {
+public enum CountryCode: String {
   case germany = "de"
   case ireland = "ie"
   case unitedStates = "us"

--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -9,7 +9,8 @@ struct NetworkRoutes {
 
   var loginAuthURL: URL {
     return URL(
-      string: "\(host("https://login.porsche.com"))/auth/api/v1/\(environment.regionCode)/public/login")!
+      string:
+        "\(host("https://login.porsche.com"))/auth/api/v1/\(environment.regionCode)/public/login")!
   }
 
   var apiAuthURL: URL {
@@ -21,22 +22,26 @@ struct NetworkRoutes {
   }
 
   var vehiclesURL: URL {
-    return URL(string: "\(host("https://api.porsche.com"))/core/api/v3/\(environment.regionCode)/vehicles")!
+    return URL(
+      string: "\(host("https://api.porsche.com"))/core/api/v3/\(environment.regionCode)/vehicles")!
   }
 
   // MARK: - Functions
 
   func vehicleSummaryURL(vehicle: Vehicle) -> URL {
-    return URL(string: "\(host("https://api.porsche.com"))/service-vehicle/vehicle-summary/\(vehicle.vin)")!
+    return URL(
+      string: "\(host("https://api.porsche.com"))/service-vehicle/vehicle-summary/\(vehicle.vin)")!
   }
 
   func vehiclePositionURL(vehicle: Vehicle) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/service-vehicle/car-finder/\(vehicle.vin)/position")!
+      string:
+        "\(host("https://api.porsche.com"))/service-vehicle/car-finder/\(vehicle.vin)/position")!
   }
 
   func vehicleCapabilitiesURL(vehicle: Vehicle) -> URL {
-    return URL(string: "\(host("https://api.porsche.com"))/service-vehicle/vcs/capabilities/\(vehicle.vin)")!
+    return URL(
+      string: "\(host("https://api.porsche.com"))/service-vehicle/vcs/capabilities/\(vehicle.vin)")!
   }
 
   func vehicleEmobilityURL(vehicle: Vehicle, capabilities: Capabilities) -> URL {
@@ -48,13 +53,15 @@ struct NetworkRoutes {
 
   func vehicleFlashURL(vehicle: Vehicle) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/service-vehicle/honk-and-flash/\(vehicle.vin)/flash")!
+      string:
+        "\(host("https://api.porsche.com"))/service-vehicle/honk-and-flash/\(vehicle.vin)/flash")!
   }
 
   func vehicleHonkAndFlashURL(vehicle: Vehicle) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/service-vehicle/honk-and-flash/\(vehicle.vin)/honk-and-flash")!
+        "\(host("https://api.porsche.com"))/service-vehicle/honk-and-flash/\(vehicle.vin)/honk-and-flash"
+    )!
   }
 
   func vehicleHonkAndFlashRemoteCommandStatusURL(

--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -67,11 +67,9 @@ struct NetworkRoutes {
   }
 
   private func host(_ defaultHost: String) -> String {
-    switch environment {
-    case .production:
-      return defaultHost
-    case .test:
+    if environment == Environment.test {
       return "http://localhost:\(kTestServerPort)"
     }
+    return defaultHost
   }
 }

--- a/Sources/PorscheConnect/PorscheConnect.swift
+++ b/Sources/PorscheConnect/PorscheConnect.swift
@@ -2,37 +2,6 @@ import Foundation
 
 // MARK: - Enums
 
-public enum Environment: String {
-  case production, test
-
-  public var countryCode: String {
-    switch self {
-    case .production:
-      return "de"
-    case .test:
-      return "ie"
-    }
-  }
-
-  public var languageCode: String {
-    switch self {
-    case .production:
-      return "de"
-    case .test:
-      return "en"
-    }
-  }
-
-  public var regionCode: String {
-    switch self {
-    case .production:
-      return "de/de_DE"
-    case .test:
-      return "ie/en_IE"
-    }
-  }
-}
-
 public enum Application {
   case api, carControl
 
@@ -75,7 +44,7 @@ public class PorscheConnect {
 
   // MARK: - Init & configuration
 
-  public init(username: String, password: String, environment: Environment = .production) {
+  public init(username: String, password: String, environment: Environment = .germany) {
     self.username = username
     self.password = password
     self.environment = environment
@@ -92,14 +61,14 @@ public class PorscheConnect {
     return !auth.expired
   }
 
-  func buildHeaders(accessToken: String, apiKey: String, countryCode: String, languageCode: String)
+  func buildHeaders(accessToken: String, apiKey: String, countryCode: CountryCode, languageCode: LanguageCode)
     -> [String: String]
   {
     return [
       "Authorization": "Bearer \(accessToken)",
       "apikey": apiKey,
-      "x-vrs-url-country": countryCode,
-      "x-vrs-url-language": "\(languageCode)_\(countryCode.uppercased())",
+      "x-vrs-url-country": countryCode.rawValue,
+      "x-vrs-url-language": "\(languageCode.rawValue)_\(countryCode.rawValue.uppercased())",
     ]
   }
 

--- a/Sources/PorscheConnect/PorscheConnect.swift
+++ b/Sources/PorscheConnect/PorscheConnect.swift
@@ -61,7 +61,9 @@ public class PorscheConnect {
     return !auth.expired
   }
 
-  func buildHeaders(accessToken: String, apiKey: String, countryCode: CountryCode, languageCode: LanguageCode)
+  func buildHeaders(
+    accessToken: String, apiKey: String, countryCode: CountryCode, languageCode: LanguageCode
+  )
     -> [String: String]
   {
     return [

--- a/Tests/PorscheConnectTests/NetworkRoutesTests.swift
+++ b/Tests/PorscheConnectTests/NetworkRoutesTests.swift
@@ -28,7 +28,7 @@ final class NetworkRoutesTests: XCTestCase {
   }
 
   func testNetworkRoutesProduction() {
-    let networkRoute = NetworkRoutes(environment: .production)
+    let networkRoute = NetworkRoutes(environment: .germany)
     XCTAssertEqual(
       URL(string: "https://login.porsche.com/auth/api/v1/de/de_DE/public/login")!,
       networkRoute.loginAuthURL)

--- a/Tests/PorscheConnectTests/PorscheConnectTests.swift
+++ b/Tests/PorscheConnectTests/PorscheConnectTests.swift
@@ -28,30 +28,38 @@ final class PorscheConnectTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: .carControl))
   }
 
-  func testEnvironmentProduction() {
-    let environment = Environment.production
+  func testEnvironmentGermany() {
+    let environment = Environment.germany
     XCTAssertNotNil(environment)
-    XCTAssertEqual("de/de_DE", environment.regionCode)
-    XCTAssertEqual("de", environment.languageCode)
-    XCTAssertEqual("de", environment.countryCode)
+    XCTAssertEqual(environment.regionCode, "de/de_DE")
+    XCTAssertEqual(environment.languageCode, .german)
+    XCTAssertEqual(environment.countryCode, .germany)
+  }
+
+  func testEnvironmentCustom() {
+    let environment = Environment(countryCode: .unitedStates, languageCode: .english, regionCode: "us/en_US")
+    XCTAssertNotNil(environment)
+    XCTAssertEqual(environment.regionCode, "us/en_US")
+    XCTAssertEqual(environment.languageCode, .english)
+    XCTAssertEqual(environment.countryCode, .unitedStates)
   }
 
   func testEnvironmentTest() {
     let environment = Environment.test
     XCTAssertNotNil(environment)
-    XCTAssertEqual("ie/en_IE", environment.regionCode)
-    XCTAssertEqual("en", environment.languageCode)
-    XCTAssertEqual("ie", environment.countryCode)
+    XCTAssertEqual(environment.regionCode, "ie/en_IE")
+    XCTAssertEqual(environment.languageCode, .english)
+    XCTAssertEqual(environment.countryCode, .ireland)
   }
 
   func testApplicationClientIdPortal() {
     let application = Application.api
-    XCTAssertEqual("4mPO3OE5Srjb1iaUGWsbqKBvvesya8oA", application.clientId)
+    XCTAssertEqual(application.clientId, "4mPO3OE5Srjb1iaUGWsbqKBvvesya8oA")
   }
 
   func testApplicationClientIdCarControl() {
     let application = Application.carControl
-    XCTAssertEqual("Ux8WmyzsOAGGmvmWnW7GLEjIILHEztAs", application.clientId)
+    XCTAssertEqual(application.clientId, "Ux8WmyzsOAGGmvmWnW7GLEjIILHEztAs")
   }
 
   func testAuthLoggerIsDefined() {

--- a/Tests/PorscheConnectTests/PorscheConnectTests.swift
+++ b/Tests/PorscheConnectTests/PorscheConnectTests.swift
@@ -37,7 +37,8 @@ final class PorscheConnectTests: BaseMockNetworkTestCase {
   }
 
   func testEnvironmentCustom() {
-    let environment = Environment(countryCode: .unitedStates, languageCode: .english, regionCode: "us/en_US")
+    let environment = Environment(
+      countryCode: .unitedStates, languageCode: .english, regionCode: "us/en_US")
     XCTAssertNotNil(environment)
     XCTAssertEqual(environment.regionCode, "us/en_US")
     XCTAssertEqual(environment.languageCode, .english)


### PR DESCRIPTION
Some endpoints return different units and localization based on the environment parameters. It's unclear if Porsche's API endpoints support more than some predetermined set of locales, so for now the supported country and language codes are hard-coded as enums to ensure correctness at compile time.