### PR TITLE
Always return non-nil response objects from the HTTP calls.

### DIFF
--- a/Sources/PorscheConnect/PorscheConnect+Auth.swift
+++ b/Sources/PorscheConnect/PorscheConnect+Auth.swift
@@ -28,8 +28,7 @@ extension PorscheConnect {
       String.self, url: networkRoutes.loginAuthURL,
       body: buildPostFormBodyFrom(dictionary: loginBody), contentType: .form,
       parseResponseBody: false)
-    if let response = result.response,
-      let statusCode = HttpStatusCode(rawValue: response.statusCode),
+    if let statusCode = HttpStatusCode(rawValue: result.response.statusCode),
       statusCode == .OK
     {
       AuthLogger.info("Login to retrieve cookies successful")
@@ -49,12 +48,11 @@ extension PorscheConnect {
       codeVerifier: codeVerifier)
     let result = try await networkClient.get(
       String.self, url: networkRoutes.apiAuthURL, params: apiAuthParams, parseResponseBody: false)
-    if let response = result.response,
-      let url = response.value(forHTTPHeaderField: "cdn-original-uri"),
+    if let url = result.response.value(forHTTPHeaderField: "cdn-original-uri"),
       let code = URLComponents(string: url)?.queryItems?.first(where: { $0.name == "code" })?.value
     {
       AuthLogger.info("Api Auth call for code successful")
-      return (code, codeVerifier, response)
+      return (code, codeVerifier, result.response)
     } else {
       throw PorscheConnectError.AuthFailure
     }
@@ -69,8 +67,7 @@ extension PorscheConnect {
     let result = try await networkClient.post(
       AuthResponse.self, url: networkRoutes.apiTokenURL,
       body: buildPostFormBodyFrom(dictionary: apiTokenBody), contentType: .form)
-    if let response = result.response,
-      let statusCode = HttpStatusCode(rawValue: response.statusCode),
+    if let statusCode = HttpStatusCode(rawValue: result.response.statusCode),
       statusCode == .OK
     {
       AuthLogger.info("Api Auth call for token successful")

--- a/Sources/PorscheConnect/PorscheConnect+CarControl.swift
+++ b/Sources/PorscheConnect/PorscheConnect+CarControl.swift
@@ -3,7 +3,7 @@ import Foundation
 extension PorscheConnect {
 
   public func summary(vehicle: Vehicle) async throws -> (
-    summary: Summary?, response: URLResponse?
+    summary: Summary?, response: HTTPURLResponse
   ) {
     let application: OAuthApplication = .carControl
 
@@ -23,7 +23,7 @@ extension PorscheConnect {
   }
 
   public func position(vehicle: Vehicle) async throws -> (
-    position: Position?, response: URLResponse?
+    position: Position?, response: HTTPURLResponse
   ) {
     let application: OAuthApplication = .carControl
 
@@ -43,7 +43,7 @@ extension PorscheConnect {
   }
 
   public func capabilities(vehicle: Vehicle) async throws -> (
-    capabilities: Capabilities?, response: URLResponse?
+    capabilities: Capabilities?, response: HTTPURLResponse
   ) {
     let application: OAuthApplication = .carControl
 
@@ -63,7 +63,7 @@ extension PorscheConnect {
   }
 
   public func emobility(vehicle: Vehicle, capabilities: Capabilities) async throws -> (
-    emobility: Emobility?, response: URLResponse?
+    emobility: Emobility?, response: HTTPURLResponse
   ) {
     let application: OAuthApplication = .carControl
 
@@ -84,7 +84,7 @@ extension PorscheConnect {
   }
 
   public func flash(vehicle: Vehicle, andHonk honk: Bool = false) async throws -> (
-    remoteCommandAccepted: RemoteCommandAccepted?, response: URLResponse?
+    remoteCommandAccepted: RemoteCommandAccepted?, response: HTTPURLResponse
   ) {
     let application: OAuthApplication = .carControl
 

--- a/Sources/PorscheConnect/PorscheConnect+CarControl.swift
+++ b/Sources/PorscheConnect/PorscheConnect+CarControl.swift
@@ -3,7 +3,7 @@ import Foundation
 extension PorscheConnect {
 
   public func summary(vehicle: Vehicle) async throws -> (
-    summary: Summary?, response: HTTPURLResponse?
+    summary: Summary?, response: URLResponse?
   ) {
     let application: OAuthApplication = .carControl
 
@@ -23,7 +23,7 @@ extension PorscheConnect {
   }
 
   public func position(vehicle: Vehicle) async throws -> (
-    position: Position?, response: HTTPURLResponse?
+    position: Position?, response: URLResponse?
   ) {
     let application: OAuthApplication = .carControl
 
@@ -43,7 +43,7 @@ extension PorscheConnect {
   }
 
   public func capabilities(vehicle: Vehicle) async throws -> (
-    capabilities: Capabilities?, response: HTTPURLResponse?
+    capabilities: Capabilities?, response: URLResponse?
   ) {
     let application: OAuthApplication = .carControl
 
@@ -63,7 +63,7 @@ extension PorscheConnect {
   }
 
   public func emobility(vehicle: Vehicle, capabilities: Capabilities) async throws -> (
-    emobility: Emobility?, response: HTTPURLResponse?
+    emobility: Emobility?, response: URLResponse?
   ) {
     let application: OAuthApplication = .carControl
 
@@ -84,7 +84,7 @@ extension PorscheConnect {
   }
 
   public func flash(vehicle: Vehicle, andHonk honk: Bool = false) async throws -> (
-    remoteCommandAccepted: RemoteCommandAccepted?, response: HTTPURLResponse?
+    remoteCommandAccepted: RemoteCommandAccepted?, response: URLResponse?
   ) {
     let application: OAuthApplication = .carControl
 

--- a/Sources/PorscheConnect/PorscheConnect+Portal.swift
+++ b/Sources/PorscheConnect/PorscheConnect+Portal.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension PorscheConnect {
 
-  public func vehicles() async throws -> (vehicles: [Vehicle]?, response: HTTPURLResponse?) {
+  public func vehicles() async throws -> (vehicles: [Vehicle]?, response: URLResponse?) {
     let application: OAuthApplication = .api
 
     _ = try await authIfRequired(application: application)

--- a/Sources/PorscheConnect/PorscheConnect+Portal.swift
+++ b/Sources/PorscheConnect/PorscheConnect+Portal.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension PorscheConnect {
 
-  public func vehicles() async throws -> (vehicles: [Vehicle]?, response: URLResponse?) {
+  public func vehicles() async throws -> (vehicles: [Vehicle]?, response: HTTPURLResponse) {
     let application: OAuthApplication = .api
 
     _ = try await authIfRequired(application: application)

--- a/Sources/PorscheConnect/PorscheConnect+RemoteCommandStatus.swift
+++ b/Sources/PorscheConnect/PorscheConnect+RemoteCommandStatus.swift
@@ -3,7 +3,7 @@ import Foundation
 extension PorscheConnect {
 
   public func checkStatus(vehicle: Vehicle, remoteCommand: RemoteCommandAccepted) async throws -> (
-    status: RemoteCommandStatus?, response: HTTPURLResponse?
+    status: RemoteCommandStatus?, response: URLResponse?
   ) {
     let application: OAuthApplication = .carControl
 

--- a/Sources/PorscheConnect/PorscheConnect+RemoteCommandStatus.swift
+++ b/Sources/PorscheConnect/PorscheConnect+RemoteCommandStatus.swift
@@ -3,7 +3,7 @@ import Foundation
 extension PorscheConnect {
 
   public func checkStatus(vehicle: Vehicle, remoteCommand: RemoteCommandAccepted) async throws -> (
-    status: RemoteCommandStatus?, response: URLResponse?
+    status: RemoteCommandStatus?, response: HTTPURLResponse?
   ) {
     let application: OAuthApplication = .carControl
 

--- a/Tests/PorscheConnectTests/NetworkClientTests.swift
+++ b/Tests/PorscheConnectTests/NetworkClientTests.swift
@@ -31,7 +31,7 @@ final class NetworkClientTests: BaseMockNetworkTestCase {
     expectation.fulfill()
 
     XCTAssertEqual("Hello World!", result.data!.message)
-    XCTAssertEqual(200, result.response!.statusCode)
+    XCTAssertEqual(200, result.response.statusCode)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -62,7 +62,7 @@ final class NetworkClientTests: BaseMockNetworkTestCase {
     expectation.fulfill()
 
     XCTAssertEqual("Hello World!", result.data!.message)
-    XCTAssertEqual(200, result.response!.statusCode)
+    XCTAssertEqual(200, result.response.statusCode)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }


### PR DESCRIPTION
From Apple's documentation on dataTask (https://developer.apple.com/documentation/foundation/urlsession/1407613-datatask):

> If a response from the server is received, regardless of whether the request completes successfully or fails, the response parameter contains that information.

We can therefor enforce the non-nil nature of the response object on successful non-throw'ing invocations of the HTTP methods, and simplify some downstream code as a result.