### PR TITLE
Add support for the "status" endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,17 @@ $ porsche show-position <username> <password> <vin>
 Latitude: 53.395367; Longitude: -6.389296; Heading: 68
 ```
 
+To show the current status of a vehicle:
+
+```bash
+$ porsche show-status <username> <password> <vin>
+
+Overall lock status: Closed and locked
+Battery level: 73.0%, Mileage: 2,206 kilometers
+Remaining range is 292 kilometers
+Next inspection in 27,842 kilometers or on Dec 10, 2024
+```
+
 To show the capabilties of a vehicle:
 
 ```bash

--- a/Sources/CommandLineTool/Command+ShowStatus.swift
+++ b/Sources/CommandLineTool/Command+ShowStatus.swift
@@ -37,14 +37,22 @@ extension Porsche {
     }
 
     private func printStatus(_ status: Status) {
-      print(NSLocalizedString("Overall lock status: \(formatted(lockStatus: status.overallLockStatus))", comment: ""))
-      print(NSLocalizedString(
-        "Battery level: \(formatted(genericValue: status.batteryLevel)), Mileage: \(formatted(distance: status.mileage))",
-        comment: ""))
+      print(
+        NSLocalizedString(
+          "Overall lock status: \(formatted(lockStatus: status.overallLockStatus))", comment: ""))
+      print(
+        NSLocalizedString(
+          "Battery level: \(formatted(genericValue: status.batteryLevel)), Mileage: \(formatted(distance: status.mileage))",
+          comment: ""))
       if let electricalRangeDistance = status.remainingRanges.electricalRange.distance {
-        print(NSLocalizedString("Remaining range is \(formatted(distance: electricalRangeDistance))", comment: ""))
+        print(
+          NSLocalizedString(
+            "Remaining range is \(formatted(distance: electricalRangeDistance))", comment: ""))
       }
-      print(NSLocalizedString("Next inspection in \(formatted(distance: status.serviceIntervals.inspection.distance, scalar: -1)) or on \(formatted(genericValue: status.serviceIntervals.inspection.time, scalar: -1))", comment: ""))
+      print(
+        NSLocalizedString(
+          "Next inspection in \(formatted(distance: status.serviceIntervals.inspection.distance, scalar: -1)) or on \(formatted(genericValue: status.serviceIntervals.inspection.time, scalar: -1))",
+          comment: ""))
     }
 
     private func formatted(genericValue: Status.GenericValue, scalar: Double = 1) -> String {

--- a/Sources/CommandLineTool/Command+ShowStatus.swift
+++ b/Sources/CommandLineTool/Command+ShowStatus.swift
@@ -1,0 +1,94 @@
+import ArgumentParser
+import Foundation
+import PorscheConnect
+
+extension Porsche {
+
+  struct ShowStatus: AsyncParsableCommand {
+    // MARK: - Properties
+
+    @OptionGroup() var options: Options
+
+    @Argument(help: ArgumentHelp(NSLocalizedString("Your vehicle VIN.", comment: "")))
+    var vin: String
+
+    // MARK: - Lifecycle
+
+    func run() async throws {
+      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let vehicle = Vehicle(vin: vin)
+      await callStatusService(porscheConnect: porscheConnect, vehicle: vehicle)
+      dispatchMain()
+    }
+
+    // MARK: - Private functions
+
+    private func callStatusService(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
+
+      do {
+        let result = try await porscheConnect.status(vehicle: vehicle)
+        if let status = result.status {
+          printStatus(status)
+        }
+        Porsche.ShowStatus.exit()
+      } catch {
+        Porsche.ShowStatus.exit(withError: error)
+      }
+    }
+
+    private func printStatus(_ status: Status) {
+      print(NSLocalizedString("Overall lock status: \(formatted(lockStatus: status.overallLockStatus))", comment: ""))
+      print(NSLocalizedString(
+        "Battery level: \(formatted(genericValue: status.batteryLevel)), Mileage: \(formatted(distance: status.mileage))",
+        comment: ""))
+      if let electricalRangeDistance = status.remainingRanges.electricalRange.distance {
+        print(NSLocalizedString("Remaining range is \(formatted(distance: electricalRangeDistance))", comment: ""))
+      }
+      print(NSLocalizedString("Next inspection in \(formatted(distance: status.serviceIntervals.inspection.distance, scalar: -1)) or on \(formatted(genericValue: status.serviceIntervals.inspection.time, scalar: -1))", comment: ""))
+    }
+
+    private func formatted(genericValue: Status.GenericValue, scalar: Double = 1) -> String {
+      let value = Double(genericValue.value) * scalar
+      switch genericValue.unit {
+      case "PERCENT":
+        return "\(value)%"
+      case "DAYS":
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        formatter.formattingContext = .middleOfSentence
+        let secondsPerDay: Double = 24 * 60 * 60
+        return formatter.string(from: Date(timeIntervalSinceNow: value * secondsPerDay))
+      default:
+        return "\(value) \(genericValue.unit)"
+      }
+    }
+
+    private func formatted(distance: Status.Distance, scalar: Double = 1) -> String {
+      let formatter = MeasurementFormatter()
+      formatter.unitStyle = .long
+      formatter.unitOptions = .providedUnit
+      formatter.locale = Locale.current
+      let value = distance.value * scalar
+      let unit: UnitLength
+      switch distance.unit {
+      case "KILOMETERS":
+        unit = .kilometers
+      case "MILES":
+        unit = .miles
+      default:
+        return "\(value)"
+      }
+      return formatter.string(from: Measurement(value: value, unit: unit))
+    }
+
+    private func formatted(lockStatus: String) -> String {
+      switch lockStatus {
+      case "CLOSED_LOCKED":
+        return NSLocalizedString("Closed and locked", comment: "The vehicle is closed and locked")
+      default:
+        return lockStatus
+      }
+    }
+  }
+}

--- a/Sources/CommandLineTool/Porsche.swift
+++ b/Sources/CommandLineTool/Porsche.swift
@@ -11,7 +11,8 @@ struct Porsche: AsyncParsableCommand {
     version: "0.1.19",
     subcommands: [
       ListVehicles.self, ShowSummary.self, ShowPosition.self, ShowCapabilities.self,
-      ShowEmobility.self, Flash.self, HonkAndFlash.self, ToggleDirectCharging.self, Lock.self, Unlock.self
+      ShowEmobility.self, ShowStatus.self, Flash.self, HonkAndFlash.self, ToggleDirectCharging.self,
+      Lock.self, Unlock.self
     ])
 
   struct Options: ParsableArguments {

--- a/Sources/CommandLineTool/Porsche.swift
+++ b/Sources/CommandLineTool/Porsche.swift
@@ -12,7 +12,7 @@ struct Porsche: AsyncParsableCommand {
     subcommands: [
       ListVehicles.self, ShowSummary.self, ShowPosition.self, ShowCapabilities.self,
       ShowEmobility.self, ShowStatus.self, Flash.self, HonkAndFlash.self, ToggleDirectCharging.self,
-      Lock.self, Unlock.self
+      Lock.self, Unlock.self,
     ])
 
   struct Options: ParsableArguments {

--- a/Sources/PorscheConnect/Models/Status.swift
+++ b/Sources/PorscheConnect/Models/Status.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+public struct Status: Codable {
+
+  // MARK: Properties
+
+  public let vin: String
+
+  // TODO: These properties are returned but it's unclear what format they are in.
+  //  let fuelLevel
+  //  let oilLevel
+
+  public let batteryLevel: GenericValue
+  public let mileage: Distance
+  public let overallLockStatus: String
+
+  public struct ServiceIntervals: Codable {
+    public struct OilService: Codable {
+      // TODO: These properties are returned but it's unclear what format they are in.
+      //  let distance:
+      //  let time
+    }
+    public let oilService: OilService
+    public struct Inspection: Codable {
+      public let distance: Distance
+      public let time: GenericValue
+    }
+    public let inspection: Inspection
+  }
+  public let serviceIntervals: ServiceIntervals
+
+  public struct RemainingRanges: Codable {
+    public struct Range: Codable {
+      public let distance: Distance?
+      public let engineType: String
+    }
+    public let conventionalRange: Range
+    public let electricalRange: Range
+  }
+  public let remainingRanges: RemainingRanges
+
+  // MARK: - Common types
+
+  public struct Distance: Codable {
+    public let value: Double
+    public let unit: String
+    public let originalValue: Double
+    public let originalUnit: String
+    public let valueInKilometers: Double
+    public let unitTranslationKey: String
+    public let unitTranslationKeyV2: String
+  }
+
+  public struct GenericValue: Codable {
+    public let value: Int
+    public let unit: String
+    public let unitTranslationKey: String
+    public let unitTranslationKeyV2: String
+  }
+}

--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -46,7 +46,9 @@ struct NetworkRoutes {
 
   func vehicleStatusURL(vehicle: Vehicle) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/vehicle-data/\(environment.regionCode)/status/\(vehicle.vin)")!
+      string:
+        "\(host("https://api.porsche.com"))/vehicle-data/\(environment.regionCode)/status/\(vehicle.vin)"
+    )!
   }
 
   func vehicleEmobilityURL(vehicle: Vehicle, capabilities: Capabilities? = nil) -> URL {
@@ -82,7 +84,8 @@ struct NetworkRoutes {
     vehicle: Vehicle, capabilities: Capabilities? = nil, enable: Bool
   ) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vehicle.vin)/toggle-direct-charging/\(enable)"
+      string:
+        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vehicle.vin)/toggle-direct-charging/\(enable)"
     )!
   }
 
@@ -90,7 +93,8 @@ struct NetworkRoutes {
     vehicle: Vehicle, capabilities: Capabilities? = nil, remoteCommand: RemoteCommandAccepted
   ) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vehicle.vin)/toggle-direct-charging/status/\(remoteCommand.identifier!)"
+      string:
+        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vehicle.vin)/toggle-direct-charging/status/\(remoteCommand.identifier!)"
     )!
   }
 
@@ -98,7 +102,8 @@ struct NetworkRoutes {
     vehicle: Vehicle, lock: Bool
   ) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vehicle.vin)/\(lock ? "quick-lock" : "security-pin/unlock")"
+      string:
+        "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vehicle.vin)/\(lock ? "quick-lock" : "security-pin/unlock")"
     )!
   }
 
@@ -106,11 +111,12 @@ struct NetworkRoutes {
     vehicle: Vehicle, remoteCommand: RemoteCommandAccepted
   ) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vehicle.vin)/\(remoteCommand.identifier!)/status"
+      string:
+        "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vehicle.vin)/\(remoteCommand.identifier!)/status"
     )!
   }
 
-// MARK: - Private
+  // MARK: - Private
 
   private func host(_ defaultHost: String) -> String {
     if environment == Environment.test {

--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -44,6 +44,11 @@ struct NetworkRoutes {
       string: "\(host("https://api.porsche.com"))/service-vehicle/vcs/capabilities/\(vehicle.vin)")!
   }
 
+  func vehicleStatusURL(vehicle: Vehicle) -> URL {
+    return URL(
+      string: "\(host("https://api.porsche.com"))/vehicle-data/\(environment.regionCode)/status/\(vehicle.vin)")!
+  }
+
   func vehicleEmobilityURL(vehicle: Vehicle, capabilities: Capabilities? = nil) -> URL {
     return URL(
       string:

--- a/Sources/PorscheConnect/PorscheConnect+CarControl.swift
+++ b/Sources/PorscheConnect/PorscheConnect+CarControl.swift
@@ -47,6 +47,17 @@ extension PorscheConnect {
     return (emobility: result.data, response: result.response)
   }
 
+  public func status(vehicle: Vehicle) async throws -> (
+    status: Status?, response: HTTPURLResponse
+  ) {
+    let headers = try await performAuthFor(application: .api)
+
+    let result = try await networkClient.get(
+      Status.self, url: networkRoutes.vehicleStatusURL(vehicle: vehicle), headers: headers,
+      jsonKeyDecodingStrategy: .useDefaultKeys)
+    return (status: result.data, response: result.response)
+  }
+
   public func flash(vehicle: Vehicle, andHonk honk: Bool = false) async throws -> (
     remoteCommandAccepted: RemoteCommandAccepted?, response: HTTPURLResponse
   ) {

--- a/Sources/PorscheConnect/PorscheConnect+CarControl.swift
+++ b/Sources/PorscheConnect/PorscheConnect+CarControl.swift
@@ -75,11 +75,14 @@ extension PorscheConnect {
     return (remoteCommandAccepted: result.data, response: result.response)
   }
 
-  public func toggleDirectCharging(vehicle: Vehicle, capabilities: Capabilities, enable: Bool = true) async throws -> (
+  public func toggleDirectCharging(
+    vehicle: Vehicle, capabilities: Capabilities, enable: Bool = true
+  ) async throws -> (
     remoteCommandAccepted: RemoteCommandAccepted?, response: HTTPURLResponse
   ) {
     let headers = try await performAuthFor(application: .carControl)
-    let url = networkRoutes.vehicleToggleDirectChargingURL(vehicle: vehicle, capabilities: capabilities, enable: enable)
+    let url = networkRoutes.vehicleToggleDirectChargingURL(
+      vehicle: vehicle, capabilities: capabilities, enable: enable)
 
     var result = try await networkClient.post(
       RemoteCommandAccepted.self, url: url, body: kBlankString, headers: headers,
@@ -108,15 +111,18 @@ extension PorscheConnect {
     let url = networkRoutes.vehicleLockUnlockURL(vehicle: vehicle, lock: false)
 
     let pinSecurity = try await networkClient.get(
-      PinSecurity.self, url: url, headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys).data
+      PinSecurity.self, url: url, headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys
+    ).data
 
-    guard let pinSecurity = pinSecurity, let pinHash = pinSecurity.generateSecurityPinHash(pin: pin) else {
+    guard let pinSecurity = pinSecurity, let pinHash = pinSecurity.generateSecurityPinHash(pin: pin)
+    else {
       throw PorscheConnectError.UnlockChallengeFailure
     }
 
-    let unlockSecurity = UnlockSecurity(challenge: pinSecurity.challenge,
-                                        securityPinHash: pinHash,
-                                        securityToken: pinSecurity.securityToken)
+    let unlockSecurity = UnlockSecurity(
+      challenge: pinSecurity.challenge,
+      securityPinHash: pinHash,
+      securityToken: pinSecurity.securityToken)
 
     var result = try await networkClient.post(
       RemoteCommandAccepted.self, url: url, body: unlockSecurity, headers: headers,

--- a/Tests/PorscheConnectTests/Mock Server Backend/MockNetworkRoutes.swift
+++ b/Tests/PorscheConnectTests/Mock Server Backend/MockNetworkRoutes.swift
@@ -25,12 +25,14 @@ final class MockNetworkRoutes {
   private static let postApiTokenPath = "/as/token.oauth2"
   private static let postFlashPath = "/service-vehicle/honk-and-flash/A1234/flash"
   private static let postHonkAndFlashPath = "/service-vehicle/honk-and-flash/A1234/honk-and-flash"
-  private static let postToggleDirectChargingOnPath = "/e-mobility/ie/en_IE/J1/A1234/toggle-direct-charging/true"
-  private static let postToggleDirectChargingOffPath = "/e-mobility/ie/en_IE/J1/A1234/toggle-direct-charging/false"
+  private static let postToggleDirectChargingOnPath =
+    "/e-mobility/ie/en_IE/J1/A1234/toggle-direct-charging/true"
+  private static let postToggleDirectChargingOffPath =
+    "/e-mobility/ie/en_IE/J1/A1234/toggle-direct-charging/false"
   private static let postLockPath = "/service-vehicle/remote-lock-unlock/A1234/quick-lock"
 
-  private static let getPostUnockPath = "/service-vehicle/remote-lock-unlock/A1234/security-pin/unlock"
-
+  private static let getPostUnockPath =
+    "/service-vehicle/remote-lock-unlock/A1234/security-pin/unlock"
 
   // MARK: - Hello World
 
@@ -259,7 +261,8 @@ final class MockNetworkRoutes {
       statusCode: 200,
       handler: { (req) -> Any in
         guard let method = req["REQUEST_METHOD"] as? String else { return }
-        return method == "GET" ? self.mockUnlockSecurityResponse() : self.mockRemoteCommandAcceptedVariantThree()
+        return method == "GET"
+          ? self.mockUnlockSecurityResponse() : self.mockRemoteCommandAcceptedVariantThree()
       })
   }
 
@@ -268,7 +271,8 @@ final class MockNetworkRoutes {
       statusCode: 200,
       handler: { (req) -> Any in
         guard let method = req["REQUEST_METHOD"] as? String else { return }
-        return method == "GET" ? self.mockUnlockSecurityResponse() : self.mockRemoteCommandAcceptedLockedError()
+        return method == "GET"
+          ? self.mockUnlockSecurityResponse() : self.mockRemoteCommandAcceptedLockedError()
       })
   }
 
@@ -277,7 +281,8 @@ final class MockNetworkRoutes {
       statusCode: 200,
       handler: { (req) -> Any in
         guard let method = req["REQUEST_METHOD"] as? String else { return }
-        return method == "GET" ? self.mockUnlockSecurityResponse() : self.mockRemoteCommandAcceptedIncorrectPinError()
+        return method == "GET"
+          ? self.mockUnlockSecurityResponse() : self.mockRemoteCommandAcceptedIncorrectPinError()
       })
   }
 
@@ -430,66 +435,66 @@ final class MockNetworkRoutes {
 
   private func mockStatusResponse() -> [String: Any?] {
     return [
-      "vin" : "ABC123",
-      "fuelLevel" : nil,
-      "oilLevel" : nil,
-      "batteryLevel" : [
-        "value" : 73,
-        "unit" : "PERCENT",
-        "unitTranslationKey" : "GRAY_SLICE_UNIT_PERCENT",
-        "unitTranslationKeyV2" : "TC.UNIT.PERCENT"
+      "vin": "ABC123",
+      "fuelLevel": nil,
+      "oilLevel": nil,
+      "batteryLevel": [
+        "value": 73,
+        "unit": "PERCENT",
+        "unitTranslationKey": "GRAY_SLICE_UNIT_PERCENT",
+        "unitTranslationKeyV2": "TC.UNIT.PERCENT",
       ],
-      "mileage" : [
-        "value" : 2195,
-        "unit" : "KILOMETERS",
-        "originalValue" : 2195,
-        "originalUnit" : "KILOMETERS",
-        "valueInKilometers" : 2195,
-        "unitTranslationKey" : "GRAY_SLICE_UNIT_KILOMETER",
-        "unitTranslationKeyV2" : "TC.UNIT.KILOMETER"
+      "mileage": [
+        "value": 2195,
+        "unit": "KILOMETERS",
+        "originalValue": 2195,
+        "originalUnit": "KILOMETERS",
+        "valueInKilometers": 2195,
+        "unitTranslationKey": "GRAY_SLICE_UNIT_KILOMETER",
+        "unitTranslationKeyV2": "TC.UNIT.KILOMETER",
       ],
-      "overallLockStatus" : "CLOSED_LOCKED",
-      "serviceIntervals" : [
-        "oilService" : [
-          "distance" : nil,
-          "time" : nil
+      "overallLockStatus": "CLOSED_LOCKED",
+      "serviceIntervals": [
+        "oilService": [
+          "distance": nil,
+          "time": nil,
         ],
-        "inspection" : [
-          "distance" : [
-            "value" : -27842,
-            "unit" : "KILOMETERS",
-            "originalValue" : -27842,
-            "originalUnit" : "KILOMETERS",
-            "valueInKilometers" : -27842,
-            "unitTranslationKey" : "GRAY_SLICE_UNIT_KILOMETER",
-            "unitTranslationKeyV2" : "TC.UNIT.KILOMETER"
+        "inspection": [
+          "distance": [
+            "value": -27842,
+            "unit": "KILOMETERS",
+            "originalValue": -27842,
+            "originalUnit": "KILOMETERS",
+            "valueInKilometers": -27842,
+            "unitTranslationKey": "GRAY_SLICE_UNIT_KILOMETER",
+            "unitTranslationKeyV2": "TC.UNIT.KILOMETER",
           ],
-          "time" : [
-            "value" : -710,
-            "unit" : "DAYS",
-            "unitTranslationKey" : "GRAY_SLICE_UNIT_DAY",
-            "unitTranslationKeyV2" : "TC.UNIT.DAYS"
-          ]
-        ]
-      ],
-      "remainingRanges" : [
-        "conventionalRange" : [
-          "distance" : nil,
-          "engineType" : "UNSUPPORTED"
+          "time": [
+            "value": -710,
+            "unit": "DAYS",
+            "unitTranslationKey": "GRAY_SLICE_UNIT_DAY",
+            "unitTranslationKeyV2": "TC.UNIT.DAYS",
+          ],
         ],
-        "electricalRange" : [
-          "distance" : [
-            "value" : 294,
-            "unit" : "KILOMETERS",
-            "originalValue" : 294,
-            "originalUnit" : "KILOMETERS",
-            "valueInKilometers" : 294,
-            "unitTranslationKey" : "GRAY_SLICE_UNIT_KILOMETER",
-            "unitTranslationKeyV2" : "TC.UNIT.KILOMETER"
+      ],
+      "remainingRanges": [
+        "conventionalRange": [
+          "distance": nil,
+          "engineType": "UNSUPPORTED",
+        ],
+        "electricalRange": [
+          "distance": [
+            "value": 294,
+            "unit": "KILOMETERS",
+            "originalValue": 294,
+            "originalUnit": "KILOMETERS",
+            "valueInKilometers": 294,
+            "unitTranslationKey": "GRAY_SLICE_UNIT_KILOMETER",
+            "unitTranslationKeyV2": "TC.UNIT.KILOMETER",
           ],
-          "engineType" : "ELECTRIC"
-        ]
-      ]
+          "engineType": "ELECTRIC",
+        ],
+      ],
     ]
   }
 
@@ -522,17 +527,23 @@ final class MockNetworkRoutes {
   }
 
   private func mockUnlockSecurityResponse() -> [String: Any] {
-    return ["securityToken": "62xuTQXWgJgnCNsqPoWv8emAeFKCMhPWH6mVwp0OaKqT61uuGxptmNVaq4evL",
-            "challenge": "D951A4D79D90EFE70C9F75A100632D756625A326110E921566B3336C32DFAE32"]
+    return [
+      "securityToken": "62xuTQXWgJgnCNsqPoWv8emAeFKCMhPWH6mVwp0OaKqT61uuGxptmNVaq4evL",
+      "challenge": "D951A4D79D90EFE70C9F75A100632D756625A326110E921566B3336C32DFAE32",
+    ]
   }
 
   private func mockRemoteCommandAcceptedLockedError() -> [String: Any?] {
-    return ["pcckErrorKey": "LOCKED_60_MINUTES", "pcckErrorMessage": nil, "pcckErrorCode": nil,
-            "pcckIsBusinessError": true]
+    return [
+      "pcckErrorKey": "LOCKED_60_MINUTES", "pcckErrorMessage": nil, "pcckErrorCode": nil,
+      "pcckIsBusinessError": true,
+    ]
   }
 
   private func mockRemoteCommandAcceptedIncorrectPinError() -> [String: Any?] {
-    return ["pcckErrorKey": "INCORRECT", "pcckErrorMessage": nil, "pcckErrorCode": nil,
-            "pcckIsBusinessError": false]
+    return [
+      "pcckErrorKey": "INCORRECT", "pcckErrorMessage": nil, "pcckErrorCode": nil,
+      "pcckIsBusinessError": false,
+    ]
   }
 }

--- a/Tests/PorscheConnectTests/Mock Server Backend/MockNetworkRoutes.swift
+++ b/Tests/PorscheConnectTests/Mock Server Backend/MockNetworkRoutes.swift
@@ -11,6 +11,7 @@ final class MockNetworkRoutes {
   private static let getSummaryPath = "/service-vehicle/vehicle-summary/A1234"
   private static let getPositionPath = "/service-vehicle/car-finder/A1234/position"
   private static let getCapabilitiesPath = "/service-vehicle/vcs/capabilities/A1234"
+  private static let getStatusPath = "/vehicle-data/ie/en_IE/status/A1234"
   private static let getEmobilityPath = "/e-mobility/ie/en_IE/J1/A1234"
 
   private static let getHonkAndFlashRemoteCommandStatusPath =
@@ -133,6 +134,19 @@ final class MockNetworkRoutes {
 
   func mockGetCapabilitiesFailure(router: Router) {
     router[MockNetworkRoutes.getCapabilitiesPath] = DataResponse(
+      statusCode: 400, statusMessage: "bad request")
+  }
+
+  // MARK: - Get Status
+
+  func mockGetStatusSuccessful(router: Router) {
+    router[MockNetworkRoutes.getStatusPath] = JSONResponse(statusCode: 200) { _ -> Any in
+      return self.mockStatusResponse()
+    }
+  }
+
+  func mockGetStatusFailure(router: Router) {
+    router[MockNetworkRoutes.getStatusPath] = DataResponse(
       statusCode: 400, statusMessage: "bad request")
   }
 
@@ -411,6 +425,71 @@ final class MockNetworkRoutes {
       ],
       "steeringWheelPosition": "RIGHT",
       "hasHonkAndFlash": true,
+    ]
+  }
+
+  private func mockStatusResponse() -> [String: Any?] {
+    return [
+      "vin" : "ABC123",
+      "fuelLevel" : nil,
+      "oilLevel" : nil,
+      "batteryLevel" : [
+        "value" : 73,
+        "unit" : "PERCENT",
+        "unitTranslationKey" : "GRAY_SLICE_UNIT_PERCENT",
+        "unitTranslationKeyV2" : "TC.UNIT.PERCENT"
+      ],
+      "mileage" : [
+        "value" : 2195,
+        "unit" : "KILOMETERS",
+        "originalValue" : 2195,
+        "originalUnit" : "KILOMETERS",
+        "valueInKilometers" : 2195,
+        "unitTranslationKey" : "GRAY_SLICE_UNIT_KILOMETER",
+        "unitTranslationKeyV2" : "TC.UNIT.KILOMETER"
+      ],
+      "overallLockStatus" : "CLOSED_LOCKED",
+      "serviceIntervals" : [
+        "oilService" : [
+          "distance" : nil,
+          "time" : nil
+        ],
+        "inspection" : [
+          "distance" : [
+            "value" : -27842,
+            "unit" : "KILOMETERS",
+            "originalValue" : -27842,
+            "originalUnit" : "KILOMETERS",
+            "valueInKilometers" : -27842,
+            "unitTranslationKey" : "GRAY_SLICE_UNIT_KILOMETER",
+            "unitTranslationKeyV2" : "TC.UNIT.KILOMETER"
+          ],
+          "time" : [
+            "value" : -710,
+            "unit" : "DAYS",
+            "unitTranslationKey" : "GRAY_SLICE_UNIT_DAY",
+            "unitTranslationKeyV2" : "TC.UNIT.DAYS"
+          ]
+        ]
+      ],
+      "remainingRanges" : [
+        "conventionalRange" : [
+          "distance" : nil,
+          "engineType" : "UNSUPPORTED"
+        ],
+        "electricalRange" : [
+          "distance" : [
+            "value" : 294,
+            "unit" : "KILOMETERS",
+            "originalValue" : 294,
+            "originalUnit" : "KILOMETERS",
+            "valueInKilometers" : 294,
+            "unitTranslationKey" : "GRAY_SLICE_UNIT_KILOMETER",
+            "unitTranslationKeyV2" : "TC.UNIT.KILOMETER"
+          ],
+          "engineType" : "ELECTRIC"
+        ]
+      ]
     ]
   }
 

--- a/Tests/PorscheConnectTests/PorscheConnect+CarControlTests.swift
+++ b/Tests/PorscheConnectTests/PorscheConnect+CarControlTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Ambassador
+import XCTest
 
 @testable import PorscheConnect
 
@@ -432,7 +432,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAcceptedResponseVariantOne(result.remoteCommandAccepted!)
-    XCTAssertEqual(RemoteCommandAccepted.RemoteCommand.honkAndFlash, result.remoteCommandAccepted!.remoteCommand)
+    XCTAssertEqual(
+      RemoteCommandAccepted.RemoteCommand.honkAndFlash, result.remoteCommandAccepted!.remoteCommand)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -476,7 +477,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAcceptedResponseVariantOne(result.remoteCommandAccepted!)
-    XCTAssertEqual(RemoteCommandAccepted.RemoteCommand.honkAndFlash, result.remoteCommandAccepted!.remoteCommand)
+    XCTAssertEqual(
+      RemoteCommandAccepted.RemoteCommand.honkAndFlash, result.remoteCommandAccepted!.remoteCommand)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -516,13 +518,16 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: application))
 
-    let result = try! await connect.toggleDirectCharging(vehicle: vehicle, capabilities: capabilites)
+    let result = try! await connect.toggleDirectCharging(
+      vehicle: vehicle, capabilities: capabilites)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAcceptedResponseVariantTwo(result.remoteCommandAccepted!)
-    XCTAssertEqual(RemoteCommandAccepted.RemoteCommand.toggleDirectCharge, result.remoteCommandAccepted!.remoteCommand)
+    XCTAssertEqual(
+      RemoteCommandAccepted.RemoteCommand.toggleDirectCharge,
+      result.remoteCommandAccepted!.remoteCommand)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -538,13 +543,16 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: application))
 
-    let result = try! await connect.toggleDirectCharging(vehicle: vehicle, capabilities: capabilites, enable: false)
+    let result = try! await connect.toggleDirectCharging(
+      vehicle: vehicle, capabilities: capabilites, enable: false)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAcceptedResponseVariantTwo(result.remoteCommandAccepted!)
-    XCTAssertEqual(RemoteCommandAccepted.RemoteCommand.toggleDirectCharge, result.remoteCommandAccepted!.remoteCommand)
+    XCTAssertEqual(
+      RemoteCommandAccepted.RemoteCommand.toggleDirectCharge,
+      result.remoteCommandAccepted!.remoteCommand)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -583,7 +591,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.toggleDirectCharging(vehicle: vehicle, capabilities: capabilites, enable: false)
+      _ = try await connect.toggleDirectCharging(
+        vehicle: vehicle, capabilities: capabilites, enable: false)
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -612,7 +621,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAcceptedResponseVariantThree(result.remoteCommandAccepted!)
-    XCTAssertEqual(RemoteCommandAccepted.RemoteCommand.lock, result.remoteCommandAccepted!.remoteCommand)
+    XCTAssertEqual(
+      RemoteCommandAccepted.RemoteCommand.lock, result.remoteCommandAccepted!.remoteCommand)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -629,7 +639,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ =  try await connect.lock(vehicle: vehicle)
+      _ = try await connect.lock(vehicle: vehicle)
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -658,7 +668,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAcceptedResponseVariantThree(result.remoteCommandAccepted!)
-    XCTAssertEqual(RemoteCommandAccepted.RemoteCommand.unlock, result.remoteCommandAccepted!.remoteCommand)
+    XCTAssertEqual(
+      RemoteCommandAccepted.RemoteCommand.unlock, result.remoteCommandAccepted!.remoteCommand)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -675,7 +686,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ =  try await connect.unlock(vehicle: vehicle, pin: "1234")
+      _ = try await connect.unlock(vehicle: vehicle, pin: "1234")
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -697,7 +708,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ =  try await connect.unlock(vehicle: vehicle, pin: "1234")
+      _ = try await connect.unlock(vehicle: vehicle, pin: "1234")
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -719,7 +730,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ =  try await connect.unlock(vehicle: vehicle, pin: "1234")
+      _ = try await connect.unlock(vehicle: vehicle, pin: "1234")
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -731,22 +742,28 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
   // MARK: - Private functions
 
-  private func assertRemoteCommandAcceptedResponseVariantOne(_ remoteCommandAccepted: RemoteCommandAccepted) {
+  private func assertRemoteCommandAcceptedResponseVariantOne(
+    _ remoteCommandAccepted: RemoteCommandAccepted
+  ) {
     XCTAssertEqual("123456789", remoteCommandAccepted.identifier)
     XCTAssertEqual("123456789", remoteCommandAccepted.id)
     XCTAssertNil(remoteCommandAccepted.requestId)
     XCTAssertEqual(
       ISO8601DateFormatter().date(from: "2022-12-27T13:19:23Z"), remoteCommandAccepted.lastUpdated)
   }
-  
-  private func assertRemoteCommandAcceptedResponseVariantTwo(_ remoteCommandAccepted: RemoteCommandAccepted) {
+
+  private func assertRemoteCommandAcceptedResponseVariantTwo(
+    _ remoteCommandAccepted: RemoteCommandAccepted
+  ) {
     XCTAssertEqual("123456789", remoteCommandAccepted.identifier)
     XCTAssertEqual("123456789", remoteCommandAccepted.requestId)
     XCTAssertNil(remoteCommandAccepted.id)
     XCTAssertNil(remoteCommandAccepted.lastUpdated)
   }
 
-  private func assertRemoteCommandAcceptedResponseVariantThree(_ remoteCommandAccepted: RemoteCommandAccepted) {
+  private func assertRemoteCommandAcceptedResponseVariantThree(
+    _ remoteCommandAccepted: RemoteCommandAccepted
+  ) {
     XCTAssertEqual("123456789", remoteCommandAccepted.identifier)
     XCTAssertEqual("123456789", remoteCommandAccepted.requestId)
     XCTAssertEqual("WP0ZZZY4MSA38703", remoteCommandAccepted.vin)


### PR DESCRIPTION
This endpoint returns a variety of status-related details about the vehicle, including mileage, charge, service intervals, and locked/open status of the car.

This change includes support for the endpoint in addition to adding a new `show-status` command and tests for the API.