### PR TITLE
Add support for more locales and locale inference in the CLI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,11 @@ SUBCOMMANDS:
   See 'porsche help <subcommand>' for detailed help.
 ```
 
+By default, the CLI tool will attempt to use your system locale for all API requests. This will
+affect the localization of the API responses. If your system locale is not supported, Germany will
+be used instead. You can choose one of the supported locales using the `--locale` flag and passing
+one of the supported locales, such as `de_DE` or `en_US`.
+
 To get a list of all the vehicles associated with your My Porsche account:
 
 ```bash

--- a/Sources/CommandLineTool/Command+Flash.swift
+++ b/Sources/CommandLineTool/Command+Flash.swift
@@ -16,7 +16,11 @@ extension Porsche {
     // MARK: - Lifecycle
 
     func run() async throws {
-      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let porscheConnect = PorscheConnect(
+        username: options.username,
+        password: options.password,
+        environment: options.resolvedEnvironment
+      )
       let vehicle = Vehicle(vin: vin)
       await callFlash(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()

--- a/Sources/CommandLineTool/Command+HonkAndFlash.swift
+++ b/Sources/CommandLineTool/Command+HonkAndFlash.swift
@@ -15,7 +15,11 @@ extension Porsche {
     // MARK: - Lifecycle
 
     func run() async throws {
-      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let porscheConnect = PorscheConnect(
+        username: options.username,
+        password: options.password,
+        environment: options.resolvedEnvironment
+      )
       let vehicle = Vehicle(vin: vin)
       await callHonkAndFlash(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()

--- a/Sources/CommandLineTool/Command+ListVehicles.swift
+++ b/Sources/CommandLineTool/Command+ListVehicles.swift
@@ -13,7 +13,11 @@ extension Porsche {
     // MARK: - Lifecycle
 
     func run() async throws {
-      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let porscheConnect = PorscheConnect(
+        username: options.username,
+        password: options.password,
+        environment: options.resolvedEnvironment
+      )
       await callListVehiclesService(porscheConnect: porscheConnect)
       dispatchMain()
     }

--- a/Sources/CommandLineTool/Command+Lock.swift
+++ b/Sources/CommandLineTool/Command+Lock.swift
@@ -16,7 +16,11 @@ extension Porsche {
     // MARK: - Lifecycle
 
     func run() async throws {
-      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let porscheConnect = PorscheConnect(
+        username: options.username,
+        password: options.password,
+        environment: options.resolvedEnvironment
+      )
       let vehicle = Vehicle(vin: vin)
       await callLock(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()

--- a/Sources/CommandLineTool/Command+ShowCapabilities.swift
+++ b/Sources/CommandLineTool/Command+ShowCapabilities.swift
@@ -16,7 +16,11 @@ extension Porsche {
     // MARK: - Lifecycle
 
     func run() async throws {
-      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let porscheConnect = PorscheConnect(
+        username: options.username,
+        password: options.password,
+        environment: options.resolvedEnvironment
+      )
       let vehicle = Vehicle(vin: vin)
       await callCapabilitiesService(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()

--- a/Sources/CommandLineTool/Command+ShowEmobility.swift
+++ b/Sources/CommandLineTool/Command+ShowEmobility.swift
@@ -16,7 +16,11 @@ extension Porsche {
     // MARK: - Lifecycle
 
     func run() async throws {
-      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let porscheConnect = PorscheConnect(
+        username: options.username,
+        password: options.password,
+        environment: options.resolvedEnvironment
+      )
       let vehicle = Vehicle(vin: vin)
       await callCapabilitiesService(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()

--- a/Sources/CommandLineTool/Command+ShowPosition.swift
+++ b/Sources/CommandLineTool/Command+ShowPosition.swift
@@ -16,7 +16,11 @@ extension Porsche {
     // MARK: - Lifecycle
 
     func run() async throws {
-      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let porscheConnect = PorscheConnect(
+        username: options.username,
+        password: options.password,
+        environment: options.resolvedEnvironment
+      )
       let vehicle = Vehicle(vin: vin)
       await callPositionService(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()

--- a/Sources/CommandLineTool/Command+ShowStatus.swift
+++ b/Sources/CommandLineTool/Command+ShowStatus.swift
@@ -15,7 +15,11 @@ extension Porsche {
     // MARK: - Lifecycle
 
     func run() async throws {
-      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let porscheConnect = PorscheConnect(
+        username: options.username,
+        password: options.password,
+        environment: options.resolvedEnvironment
+      )
       let vehicle = Vehicle(vin: vin)
       await callStatusService(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()

--- a/Sources/CommandLineTool/Command+ShowStatus.swift
+++ b/Sources/CommandLineTool/Command+ShowStatus.swift
@@ -37,14 +37,22 @@ extension Porsche {
     }
 
     private func printStatus(_ status: Status) {
-      print(NSLocalizedString("Overall lock status: \(formatted(lockStatus: status.overallLockStatus))", comment: ""))
-      print(NSLocalizedString(
-        "Battery level: \(formatted(genericValue: status.batteryLevel)), Mileage: \(formatted(distance: status.mileage))",
-        comment: ""))
+      print(
+        NSLocalizedString(
+          "Overall lock status: \(formatted(lockStatus: status.overallLockStatus))", comment: ""))
+      print(
+        NSLocalizedString(
+          "Battery level: \(formatted(genericValue: status.batteryLevel)), Mileage: \(formatted(distance: status.mileage))",
+          comment: ""))
       if let electricalRangeDistance = status.remainingRanges.electricalRange.distance {
-        print(NSLocalizedString("Remaining range is \(formatted(distance: electricalRangeDistance))", comment: ""))
+        print(
+          NSLocalizedString(
+            "Remaining range is \(formatted(distance: electricalRangeDistance))", comment: ""))
       }
-      print(NSLocalizedString("Next inspection in \(formatted(distance: status.serviceIntervals.inspection.distance, scalar: -1)) or on \(formatted(genericValue: status.serviceIntervals.inspection.time, scalar: -1))", comment: ""))
+      print(
+        NSLocalizedString(
+          "Next inspection in \(formatted(distance: status.serviceIntervals.inspection.distance, scalar: -1)) or on \(formatted(genericValue: status.serviceIntervals.inspection.time, scalar: -1))",
+          comment: ""))
     }
 
     private func formatted(genericValue: Status.GenericValue, scalar: Double = 1) -> String {

--- a/Sources/CommandLineTool/Command+ShowStatus.swift
+++ b/Sources/CommandLineTool/Command+ShowStatus.swift
@@ -1,0 +1,94 @@
+import ArgumentParser
+import Foundation
+import PorscheConnect
+
+extension Porsche {
+
+  struct ShowStatus: AsyncParsableCommand {
+    // MARK: - Properties
+
+    @OptionGroup() var options: Options
+
+    @Argument(help: ArgumentHelp(NSLocalizedString("Your vehicle VIN.", comment: "")))
+    var vin: String
+
+    // MARK: - Lifecycle
+
+    func run() async throws {
+      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let vehicle = Vehicle(vin: vin)
+      await callStatusService(porscheConnect: porscheConnect, vehicle: vehicle)
+      dispatchMain()
+    }
+
+    // MARK: - Private functions
+
+    private func callStatusService(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
+
+      do {
+        let result = try await porscheConnect.status(vehicle: vehicle)
+        if let status = result.status {
+          printStatus(status)
+        }
+        Porsche.ShowStatus.exit()
+      } catch {
+        Porsche.ShowStatus.exit(withError: error)
+      }
+    }
+
+    private func printStatus(_ status: Status) {
+      print(NSLocalizedString("Overall lock status: \(formatted(lockStatus: status.overallLockStatus))", comment: ""))
+      print(NSLocalizedString(
+        "Battery level: \(formatted(genericValue: status.batteryLevel)), Mileage: \(formatted(distance: status.mileage))",
+        comment: ""))
+      if let electricalRangeDistance = status.remainingRanges.electricalRange.distance {
+        print(NSLocalizedString("Remaining range is \(formatted(distance: electricalRangeDistance))", comment: ""))
+      }
+      print(NSLocalizedString("Next inspection in \(formatted(distance: status.serviceIntervals.inspection.distance, scalar: -1)) or on \(formatted(genericValue: status.serviceIntervals.inspection.time, scalar: -1))", comment: ""))
+    }
+
+    private func formatted(genericValue: Status.GenericValue, scalar: Double = 1) -> String {
+      let value = Double(genericValue.value) * scalar
+      switch genericValue.unit {
+      case "PERCENT":
+        return "\(value)%"
+      case "DAYS":
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        formatter.formattingContext = .middleOfSentence
+        let secondsPerDay: Double = 24 * 60 * 60
+        return formatter.string(from: Date(timeIntervalSinceNow: value * secondsPerDay))
+      default:
+        return "\(value) \(genericValue.unit)"
+      }
+    }
+
+    private func formatted(distance: Status.Distance, scalar: Double = 1) -> String {
+      let formatter = MeasurementFormatter()
+      formatter.unitStyle = .long
+      formatter.unitOptions = .providedUnit
+      formatter.locale = Locale.current
+      let value = distance.value * scalar
+      let unit: UnitLength
+      switch distance.unit {
+      case "KILOMETERS":
+        unit = .kilometers
+      case "MILES":
+        unit = .miles
+      default:
+        return "\(value)"
+      }
+      return formatter.string(from: Measurement(value: value, unit: unit))
+    }
+
+    private func formatted(lockStatus: String) -> String {
+      switch lockStatus {
+      case "CLOSED_LOCKED":
+        return NSLocalizedString("Closed and locked", comment: "The vehicle is closed and locked")
+      default:
+        return lockStatus
+      }
+    }
+  }
+}

--- a/Sources/CommandLineTool/Command+ShowSummary.swift
+++ b/Sources/CommandLineTool/Command+ShowSummary.swift
@@ -15,7 +15,11 @@ extension Porsche {
     // MARK: - Lifecycle
 
     func run() async throws {
-      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let porscheConnect = PorscheConnect(
+        username: options.username,
+        password: options.password,
+        environment: options.resolvedEnvironment
+      )
       let vehicle = Vehicle(vin: vin)
       await callSummaryService(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()

--- a/Sources/CommandLineTool/Command+ToggleDirectCharging.swift
+++ b/Sources/CommandLineTool/Command+ToggleDirectCharging.swift
@@ -19,7 +19,11 @@ extension Porsche {
     // MARK: - Lifecycle
 
     func run() async throws {
-      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let porscheConnect = PorscheConnect(
+        username: options.username,
+        password: options.password,
+        environment: options.resolvedEnvironment
+      )
       let vehicle = Vehicle(vin: vin)
       await callCapabilitiesService(porscheConnect: porscheConnect, vehicle: vehicle)
       dispatchMain()

--- a/Sources/CommandLineTool/Command+Unlock.swift
+++ b/Sources/CommandLineTool/Command+Unlock.swift
@@ -19,7 +19,11 @@ extension Porsche {
     // MARK: - Lifecycle
 
     func run() async throws {
-      let porscheConnect = PorscheConnect(username: options.username, password: options.password)
+      let porscheConnect = PorscheConnect(
+        username: options.username,
+        password: options.password,
+        environment: options.resolvedEnvironment
+      )
       let vehicle = Vehicle(vin: vin)
       await callUnlock(porscheConnect: porscheConnect, vehicle: vehicle, pin: pin)
       dispatchMain()

--- a/Sources/CommandLineTool/Porsche.swift
+++ b/Sources/CommandLineTool/Porsche.swift
@@ -11,7 +11,8 @@ struct Porsche: AsyncParsableCommand {
     version: "0.1.19",
     subcommands: [
       ListVehicles.self, ShowSummary.self, ShowPosition.self, ShowCapabilities.self,
-      ShowEmobility.self, Flash.self, HonkAndFlash.self, ToggleDirectCharging.self, Lock.self, Unlock.self
+      ShowEmobility.self, ShowStatus.self, Flash.self, HonkAndFlash.self, ToggleDirectCharging.self,
+      Lock.self, Unlock.self
     ])
 
   struct Options: ParsableArguments {

--- a/Sources/CommandLineTool/Porsche.swift
+++ b/Sources/CommandLineTool/Porsche.swift
@@ -12,7 +12,7 @@ struct Porsche: AsyncParsableCommand {
     subcommands: [
       ListVehicles.self, ShowSummary.self, ShowPosition.self, ShowCapabilities.self,
       ShowEmobility.self, ShowStatus.self, Flash.self, HonkAndFlash.self, ToggleDirectCharging.self,
-      Lock.self, Unlock.self
+      Lock.self, Unlock.self,
     ])
 
   struct Options: ParsableArguments {

--- a/Sources/CommandLineTool/Porsche.swift
+++ b/Sources/CommandLineTool/Porsche.swift
@@ -66,8 +66,7 @@ struct Porsche: AsyncParsableCommand {
     }
     @Option(help: ArgumentHelp(NSLocalizedString(
       "The locale to use when making API calls. "
-      + "Defaults to the system locale if possible, otherwise defaults to Germany. "
-      + "Valid values are: \(LocaleOption.allCases.map { $0.rawValue }.joined(separator: ", "))",
+      + "Defaults to the system locale if possible, otherwise defaults to Germany. ",
       comment: ""
     )))
     var locale: LocaleOption? = nil

--- a/Sources/CommandLineTool/Porsche.swift
+++ b/Sources/CommandLineTool/Porsche.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Foundation
+import PorscheConnect
 
 // MARK: - Main
 
@@ -23,5 +24,69 @@ struct Porsche: AsyncParsableCommand {
 
     @Argument(help: ArgumentHelp(NSLocalizedString("Your MyPorsche password.", comment: "")))
     var password: String
+
+    // The list of supported locales was determined via brute force authorization attempts using
+    // the following code:
+    //
+    //    let identifiers = Locale.availableIdentifiers
+    //    for identifier in identifiers {
+    //      guard let environment = Environment(locale: Locale(identifier: identifier)) else {
+    //        continue
+    //      }
+    //      let porscheConnect = PorscheConnect(
+    //        username: options.username,
+    //        password: options.password,
+    //        environment: environment
+    //      )
+    //      await callListVehiclesService(porscheConnect: porscheConnect)
+    //    }
+    enum LocaleOption: String, ExpressibleByArgument, CaseIterable {
+      case china = "zh_CN"
+      case czechia = "cs_CZ"
+      case denmark = "da_DK"
+      case estonia = "et_EE"
+      case finland = "fi_FI"
+      case france = "fr_FR"
+      case germany = "de_DE"
+      case italy = "it_IT"
+      case japan = "ja_JP"
+      case korea = "ko_KR"
+      case latvia = "lv_LV"
+      case lithuania = "lt_LT"
+      case netherlands = "nl_NL"
+      case poland = "pl_PL"
+      case portugal = "pt_PT"
+      case russia = "ru_RU"
+      case spain = "es_ES"
+      case sweden = "sv_SE"
+      case taiwan = "zh_TW"
+      case turkey = "tr_TR"
+      case unitedKingdom = "en_GB"
+      case unitedStates = "en_US"
+    }
+    @Option(help: ArgumentHelp(NSLocalizedString(
+      "The locale to use when making API calls. "
+      + "Defaults to the system locale if possible, otherwise defaults to Germany. "
+      + "Valid values are: \(LocaleOption.allCases.map { $0.rawValue }.joined(separator: ", "))",
+      comment: ""
+    )))
+    var locale: LocaleOption? = nil
+
+    private var resolvedLocale: Locale {
+      // Prioritize the provided locale option, if one was given.
+      if let givenLocale = locale {
+        return Locale(identifier: givenLocale.rawValue)
+      }
+      // If no locale was provided, try to use the user's current locale.
+      if let currentLocale = LocaleOption(rawValue: Locale.current.identifier) {
+        return Locale(identifier: currentLocale.rawValue)
+      }
+      // If the system locale wasn't supported at all, fall back to Germany.
+      return Locale(identifier: LocaleOption.germany.rawValue)
+    }
+
+    var resolvedEnvironment: Environment {
+      return .init(locale: resolvedLocale) ?? .germany
+    }
   }
 }

--- a/Sources/PorscheConnect/Environment.swift
+++ b/Sources/PorscheConnect/Environment.swift
@@ -4,23 +4,28 @@ import Foundation
 ///
 /// The environment affects the units and localization of API responses.
 public struct Environment: Equatable {
-  public let countryCode: CountryCode
-  public let languageCode: LanguageCode
+  public let countryCode: String
+  public let languageCode: String
   public let regionCode: String
 
-  static public let germany = Environment(
-    countryCode: .germany, languageCode: .german, regionCode: "de/de_DE")
-  static let test = Environment(
-    countryCode: .ireland, languageCode: .english, regionCode: "ie/en_IE")
-}
+  public init(countryCode: String, languageCode: String, regionCode: String) {
+    self.countryCode = countryCode
+    self.languageCode = languageCode
+    self.regionCode = regionCode
+  }
 
-public enum CountryCode: String {
-  case germany = "de"
-  case ireland = "ie"
-  case unitedStates = "us"
-}
-
-public enum LanguageCode: String {
-  case english = "en"
-  case german = "de"
+  /// Initializes the Environment with a given locale, if possible.
+  ///
+  /// - Parameter locale:The Locale must have an identifier consisting of both the country and language,
+  ///   separated by a `-` or `_` character. For example, `de_DE` or `en_US`.
+  public init?(locale: Locale) {
+    guard let regionCode = locale.regionCode, let languageCode = locale.languageCode else {
+      return nil
+    }
+    self.countryCode = regionCode.lowercased()
+    self.languageCode = languageCode.lowercased()
+    self.regionCode = "\(countryCode)/\(locale.identifier.replacingOccurrences(of: "-", with: "_"))"
+  }
+  static public let germany = Environment(locale: Locale(identifier: "de_DE"))!
+  static let test = Environment(locale: Locale(identifier: "en_IE"))!
 }

--- a/Sources/PorscheConnect/Models/Status.swift
+++ b/Sources/PorscheConnect/Models/Status.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+public struct Status: Codable {
+
+  // MARK: Properties
+
+  public let vin: String
+
+  // TODO: These properties are returned but it's unclear what format they are in.
+  //  let fuelLevel
+  //  let oilLevel
+
+  public let batteryLevel: GenericValue
+  public let mileage: Distance
+  public let overallLockStatus: String
+
+  public struct ServiceIntervals: Codable {
+    public struct OilService: Codable {
+      // TODO: These properties are returned but it's unclear what format they are in.
+      //  let distance:
+      //  let time
+    }
+    public let oilService: OilService
+    public struct Inspection: Codable {
+      public let distance: Distance
+      public let time: GenericValue
+    }
+    public let inspection: Inspection
+  }
+  public let serviceIntervals: ServiceIntervals
+
+  public struct RemainingRanges: Codable {
+    public struct Range: Codable {
+      public let distance: Distance?
+      public let engineType: String
+    }
+    public let conventionalRange: Range
+    public let electricalRange: Range
+  }
+  public let remainingRanges: RemainingRanges
+
+  // MARK: - Common types
+
+  public struct Distance: Codable {
+    public let value: Double
+    public let unit: String
+    public let originalValue: Double
+    public let originalUnit: String
+    public let valueInKilometers: Double
+    public let unitTranslationKey: String
+    public let unitTranslationKeyV2: String
+  }
+
+  public struct GenericValue: Codable {
+    public let value: Int
+    public let unit: String
+    public let unitTranslationKey: String
+    public let unitTranslationKeyV2: String
+  }
+}

--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -46,7 +46,9 @@ struct NetworkRoutes {
 
   func vehicleStatusURL(vehicle: Vehicle) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/vehicle-data/\(environment.regionCode)/status/\(vehicle.vin)")!
+      string:
+        "\(host("https://api.porsche.com"))/vehicle-data/\(environment.regionCode)/status/\(vehicle.vin)"
+    )!
   }
 
   func vehicleEmobilityURL(vehicle: Vehicle, capabilities: Capabilities? = nil) -> URL {
@@ -82,7 +84,8 @@ struct NetworkRoutes {
     vehicle: Vehicle, capabilities: Capabilities? = nil, enable: Bool
   ) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vehicle.vin)/toggle-direct-charging/\(enable)"
+      string:
+        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vehicle.vin)/toggle-direct-charging/\(enable)"
     )!
   }
 
@@ -90,7 +93,8 @@ struct NetworkRoutes {
     vehicle: Vehicle, capabilities: Capabilities? = nil, remoteCommand: RemoteCommandAccepted
   ) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vehicle.vin)/toggle-direct-charging/status/\(remoteCommand.identifier!)"
+      string:
+        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vehicle.vin)/toggle-direct-charging/status/\(remoteCommand.identifier!)"
     )!
   }
 
@@ -98,7 +102,8 @@ struct NetworkRoutes {
     vehicle: Vehicle, lock: Bool
   ) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vehicle.vin)/\(lock ? "quick-lock" : "security-pin/unlock")"
+      string:
+        "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vehicle.vin)/\(lock ? "quick-lock" : "security-pin/unlock")"
     )!
   }
 
@@ -106,11 +111,12 @@ struct NetworkRoutes {
     vehicle: Vehicle, remoteCommand: RemoteCommandAccepted
   ) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vehicle.vin)/\(remoteCommand.identifier!)/status"
+      string:
+        "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vehicle.vin)/\(remoteCommand.identifier!)/status"
     )!
   }
 
-// MARK: - Private
+  // MARK: - Private
 
   private func host(_ defaultHost: String) -> String {
     if environment == Environment.test {

--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -44,6 +44,11 @@ struct NetworkRoutes {
       string: "\(host("https://api.porsche.com"))/service-vehicle/vcs/capabilities/\(vehicle.vin)")!
   }
 
+  func vehicleStatusURL(vehicle: Vehicle) -> URL {
+    return URL(
+      string: "\(host("https://api.porsche.com"))/vehicle-data/\(environment.regionCode)/status/\(vehicle.vin)")!
+  }
+
   func vehicleEmobilityURL(vehicle: Vehicle, capabilities: Capabilities? = nil) -> URL {
     return URL(
       string:

--- a/Sources/PorscheConnect/PorscheConnect+CarControl.swift
+++ b/Sources/PorscheConnect/PorscheConnect+CarControl.swift
@@ -47,6 +47,17 @@ extension PorscheConnect {
     return (emobility: result.data, response: result.response)
   }
 
+  public func status(vehicle: Vehicle) async throws -> (
+    status: Status?, response: HTTPURLResponse
+  ) {
+    let headers = try await performAuthFor(application: .api)
+
+    let result = try await networkClient.get(
+      Status.self, url: networkRoutes.vehicleStatusURL(vehicle: vehicle), headers: headers,
+      jsonKeyDecodingStrategy: .useDefaultKeys)
+    return (status: result.data, response: result.response)
+  }
+
   public func flash(vehicle: Vehicle, andHonk honk: Bool = false) async throws -> (
     remoteCommandAccepted: RemoteCommandAccepted?, response: HTTPURLResponse
   ) {

--- a/Sources/PorscheConnect/PorscheConnect+CarControl.swift
+++ b/Sources/PorscheConnect/PorscheConnect+CarControl.swift
@@ -75,11 +75,14 @@ extension PorscheConnect {
     return (remoteCommandAccepted: result.data, response: result.response)
   }
 
-  public func toggleDirectCharging(vehicle: Vehicle, capabilities: Capabilities, enable: Bool = true) async throws -> (
+  public func toggleDirectCharging(
+    vehicle: Vehicle, capabilities: Capabilities, enable: Bool = true
+  ) async throws -> (
     remoteCommandAccepted: RemoteCommandAccepted?, response: HTTPURLResponse
   ) {
     let headers = try await performAuthFor(application: .carControl)
-    let url = networkRoutes.vehicleToggleDirectChargingURL(vehicle: vehicle, capabilities: capabilities, enable: enable)
+    let url = networkRoutes.vehicleToggleDirectChargingURL(
+      vehicle: vehicle, capabilities: capabilities, enable: enable)
 
     var result = try await networkClient.post(
       RemoteCommandAccepted.self, url: url, body: kBlankString, headers: headers,
@@ -108,15 +111,18 @@ extension PorscheConnect {
     let url = networkRoutes.vehicleLockUnlockURL(vehicle: vehicle, lock: false)
 
     let pinSecurity = try await networkClient.get(
-      PinSecurity.self, url: url, headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys).data
+      PinSecurity.self, url: url, headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys
+    ).data
 
-    guard let pinSecurity = pinSecurity, let pinHash = pinSecurity.generateSecurityPinHash(pin: pin) else {
+    guard let pinSecurity = pinSecurity, let pinHash = pinSecurity.generateSecurityPinHash(pin: pin)
+    else {
       throw PorscheConnectError.UnlockChallengeFailure
     }
 
-    let unlockSecurity = UnlockSecurity(challenge: pinSecurity.challenge,
-                                        securityPinHash: pinHash,
-                                        securityToken: pinSecurity.securityToken)
+    let unlockSecurity = UnlockSecurity(
+      challenge: pinSecurity.challenge,
+      securityPinHash: pinHash,
+      securityToken: pinSecurity.securityToken)
 
     var result = try await networkClient.post(
       RemoteCommandAccepted.self, url: url, body: unlockSecurity, headers: headers,

--- a/Sources/PorscheConnect/PorscheConnect.swift
+++ b/Sources/PorscheConnect/PorscheConnect.swift
@@ -67,8 +67,8 @@ public class PorscheConnect {
     return [
       "Authorization": "Bearer \(auth.accessToken)",
       "apikey": apiKey,
-      "x-vrs-url-country": environment.countryCode.rawValue,
-      "x-vrs-url-language": "\(environment.languageCode.rawValue)_\(environment.countryCode.rawValue.uppercased())",
+      "x-vrs-url-country": environment.countryCode,
+      "x-vrs-url-language": "\(environment.languageCode)_\(environment.countryCode.uppercased())",
     ]
   }
 

--- a/Tests/PorscheConnectTests/Common/TestConstants.swift
+++ b/Tests/PorscheConnectTests/Common/TestConstants.swift
@@ -26,3 +26,16 @@ func buildCapabilites() -> Capabilities {
   decoder.keyDecodingStrategy = .useDefaultKeys
   return try! decoder.decode(Capabilities.self, from: json)
 }
+
+// MARK: - Localization codes
+
+enum CountryCode: String {
+  case germany = "de"
+  case ireland = "ie"
+  case unitedStates = "us"
+}
+
+enum LanguageCode: String {
+  case english = "en"
+  case german = "de"
+}

--- a/Tests/PorscheConnectTests/Mock Server Backend/MockNetworkRoutes.swift
+++ b/Tests/PorscheConnectTests/Mock Server Backend/MockNetworkRoutes.swift
@@ -25,12 +25,14 @@ final class MockNetworkRoutes {
   private static let postApiTokenPath = "/as/token.oauth2"
   private static let postFlashPath = "/service-vehicle/honk-and-flash/A1234/flash"
   private static let postHonkAndFlashPath = "/service-vehicle/honk-and-flash/A1234/honk-and-flash"
-  private static let postToggleDirectChargingOnPath = "/e-mobility/ie/en_IE/J1/A1234/toggle-direct-charging/true"
-  private static let postToggleDirectChargingOffPath = "/e-mobility/ie/en_IE/J1/A1234/toggle-direct-charging/false"
+  private static let postToggleDirectChargingOnPath =
+    "/e-mobility/ie/en_IE/J1/A1234/toggle-direct-charging/true"
+  private static let postToggleDirectChargingOffPath =
+    "/e-mobility/ie/en_IE/J1/A1234/toggle-direct-charging/false"
   private static let postLockPath = "/service-vehicle/remote-lock-unlock/A1234/quick-lock"
 
-  private static let getPostUnockPath = "/service-vehicle/remote-lock-unlock/A1234/security-pin/unlock"
-
+  private static let getPostUnockPath =
+    "/service-vehicle/remote-lock-unlock/A1234/security-pin/unlock"
 
   // MARK: - Hello World
 
@@ -259,7 +261,8 @@ final class MockNetworkRoutes {
       statusCode: 200,
       handler: { (req) -> Any in
         guard let method = req["REQUEST_METHOD"] as? String else { return }
-        return method == "GET" ? self.mockUnlockSecurityResponse() : self.mockRemoteCommandAcceptedVariantThree()
+        return method == "GET"
+          ? self.mockUnlockSecurityResponse() : self.mockRemoteCommandAcceptedVariantThree()
       })
   }
 
@@ -268,7 +271,8 @@ final class MockNetworkRoutes {
       statusCode: 200,
       handler: { (req) -> Any in
         guard let method = req["REQUEST_METHOD"] as? String else { return }
-        return method == "GET" ? self.mockUnlockSecurityResponse() : self.mockRemoteCommandAcceptedLockedError()
+        return method == "GET"
+          ? self.mockUnlockSecurityResponse() : self.mockRemoteCommandAcceptedLockedError()
       })
   }
 
@@ -277,7 +281,8 @@ final class MockNetworkRoutes {
       statusCode: 200,
       handler: { (req) -> Any in
         guard let method = req["REQUEST_METHOD"] as? String else { return }
-        return method == "GET" ? self.mockUnlockSecurityResponse() : self.mockRemoteCommandAcceptedIncorrectPinError()
+        return method == "GET"
+          ? self.mockUnlockSecurityResponse() : self.mockRemoteCommandAcceptedIncorrectPinError()
       })
   }
 
@@ -430,66 +435,66 @@ final class MockNetworkRoutes {
 
   private func mockStatusResponse() -> [String: Any?] {
     return [
-      "vin" : "ABC123",
-      "fuelLevel" : nil,
-      "oilLevel" : nil,
-      "batteryLevel" : [
-        "value" : 73,
-        "unit" : "PERCENT",
-        "unitTranslationKey" : "GRAY_SLICE_UNIT_PERCENT",
-        "unitTranslationKeyV2" : "TC.UNIT.PERCENT"
+      "vin": "ABC123",
+      "fuelLevel": nil,
+      "oilLevel": nil,
+      "batteryLevel": [
+        "value": 73,
+        "unit": "PERCENT",
+        "unitTranslationKey": "GRAY_SLICE_UNIT_PERCENT",
+        "unitTranslationKeyV2": "TC.UNIT.PERCENT",
       ],
-      "mileage" : [
-        "value" : 2195,
-        "unit" : "KILOMETERS",
-        "originalValue" : 2195,
-        "originalUnit" : "KILOMETERS",
-        "valueInKilometers" : 2195,
-        "unitTranslationKey" : "GRAY_SLICE_UNIT_KILOMETER",
-        "unitTranslationKeyV2" : "TC.UNIT.KILOMETER"
+      "mileage": [
+        "value": 2195,
+        "unit": "KILOMETERS",
+        "originalValue": 2195,
+        "originalUnit": "KILOMETERS",
+        "valueInKilometers": 2195,
+        "unitTranslationKey": "GRAY_SLICE_UNIT_KILOMETER",
+        "unitTranslationKeyV2": "TC.UNIT.KILOMETER",
       ],
-      "overallLockStatus" : "CLOSED_LOCKED",
-      "serviceIntervals" : [
-        "oilService" : [
-          "distance" : nil,
-          "time" : nil
+      "overallLockStatus": "CLOSED_LOCKED",
+      "serviceIntervals": [
+        "oilService": [
+          "distance": nil,
+          "time": nil,
         ],
-        "inspection" : [
-          "distance" : [
-            "value" : -27842,
-            "unit" : "KILOMETERS",
-            "originalValue" : -27842,
-            "originalUnit" : "KILOMETERS",
-            "valueInKilometers" : -27842,
-            "unitTranslationKey" : "GRAY_SLICE_UNIT_KILOMETER",
-            "unitTranslationKeyV2" : "TC.UNIT.KILOMETER"
+        "inspection": [
+          "distance": [
+            "value": -27842,
+            "unit": "KILOMETERS",
+            "originalValue": -27842,
+            "originalUnit": "KILOMETERS",
+            "valueInKilometers": -27842,
+            "unitTranslationKey": "GRAY_SLICE_UNIT_KILOMETER",
+            "unitTranslationKeyV2": "TC.UNIT.KILOMETER",
           ],
-          "time" : [
-            "value" : -710,
-            "unit" : "DAYS",
-            "unitTranslationKey" : "GRAY_SLICE_UNIT_DAY",
-            "unitTranslationKeyV2" : "TC.UNIT.DAYS"
-          ]
-        ]
-      ],
-      "remainingRanges" : [
-        "conventionalRange" : [
-          "distance" : nil,
-          "engineType" : "UNSUPPORTED"
+          "time": [
+            "value": -710,
+            "unit": "DAYS",
+            "unitTranslationKey": "GRAY_SLICE_UNIT_DAY",
+            "unitTranslationKeyV2": "TC.UNIT.DAYS",
+          ],
         ],
-        "electricalRange" : [
-          "distance" : [
-            "value" : 294,
-            "unit" : "KILOMETERS",
-            "originalValue" : 294,
-            "originalUnit" : "KILOMETERS",
-            "valueInKilometers" : 294,
-            "unitTranslationKey" : "GRAY_SLICE_UNIT_KILOMETER",
-            "unitTranslationKeyV2" : "TC.UNIT.KILOMETER"
+      ],
+      "remainingRanges": [
+        "conventionalRange": [
+          "distance": nil,
+          "engineType": "UNSUPPORTED",
+        ],
+        "electricalRange": [
+          "distance": [
+            "value": 294,
+            "unit": "KILOMETERS",
+            "originalValue": 294,
+            "originalUnit": "KILOMETERS",
+            "valueInKilometers": 294,
+            "unitTranslationKey": "GRAY_SLICE_UNIT_KILOMETER",
+            "unitTranslationKeyV2": "TC.UNIT.KILOMETER",
           ],
-          "engineType" : "ELECTRIC"
-        ]
-      ]
+          "engineType": "ELECTRIC",
+        ],
+      ],
     ]
   }
 
@@ -522,17 +527,23 @@ final class MockNetworkRoutes {
   }
 
   private func mockUnlockSecurityResponse() -> [String: Any] {
-    return ["securityToken": "62xuTQXWgJgnCNsqPoWv8emAeFKCMhPWH6mVwp0OaKqT61uuGxptmNVaq4evL",
-            "challenge": "D951A4D79D90EFE70C9F75A100632D756625A326110E921566B3336C32DFAE32"]
+    return [
+      "securityToken": "62xuTQXWgJgnCNsqPoWv8emAeFKCMhPWH6mVwp0OaKqT61uuGxptmNVaq4evL",
+      "challenge": "D951A4D79D90EFE70C9F75A100632D756625A326110E921566B3336C32DFAE32",
+    ]
   }
 
   private func mockRemoteCommandAcceptedLockedError() -> [String: Any?] {
-    return ["pcckErrorKey": "LOCKED_60_MINUTES", "pcckErrorMessage": nil, "pcckErrorCode": nil,
-            "pcckIsBusinessError": true]
+    return [
+      "pcckErrorKey": "LOCKED_60_MINUTES", "pcckErrorMessage": nil, "pcckErrorCode": nil,
+      "pcckIsBusinessError": true,
+    ]
   }
 
   private func mockRemoteCommandAcceptedIncorrectPinError() -> [String: Any?] {
-    return ["pcckErrorKey": "INCORRECT", "pcckErrorMessage": nil, "pcckErrorCode": nil,
-            "pcckIsBusinessError": false]
+    return [
+      "pcckErrorKey": "INCORRECT", "pcckErrorMessage": nil, "pcckErrorCode": nil,
+      "pcckIsBusinessError": false,
+    ]
   }
 }

--- a/Tests/PorscheConnectTests/Mock Server Backend/MockNetworkRoutes.swift
+++ b/Tests/PorscheConnectTests/Mock Server Backend/MockNetworkRoutes.swift
@@ -11,6 +11,7 @@ final class MockNetworkRoutes {
   private static let getSummaryPath = "/service-vehicle/vehicle-summary/A1234"
   private static let getPositionPath = "/service-vehicle/car-finder/A1234/position"
   private static let getCapabilitiesPath = "/service-vehicle/vcs/capabilities/A1234"
+  private static let getStatusPath = "/vehicle-data/ie/en_IE/status/A1234"
   private static let getEmobilityPath = "/e-mobility/ie/en_IE/J1/A1234"
 
   private static let getHonkAndFlashRemoteCommandStatusPath =
@@ -133,6 +134,19 @@ final class MockNetworkRoutes {
 
   func mockGetCapabilitiesFailure(router: Router) {
     router[MockNetworkRoutes.getCapabilitiesPath] = DataResponse(
+      statusCode: 400, statusMessage: "bad request")
+  }
+
+  // MARK: - Get Status
+
+  func mockGetStatusSuccessful(router: Router) {
+    router[MockNetworkRoutes.getStatusPath] = JSONResponse(statusCode: 200) { _ -> Any in
+      return self.mockStatusResponse()
+    }
+  }
+
+  func mockGetStatusFailure(router: Router) {
+    router[MockNetworkRoutes.getStatusPath] = DataResponse(
       statusCode: 400, statusMessage: "bad request")
   }
 
@@ -411,6 +425,71 @@ final class MockNetworkRoutes {
       ],
       "steeringWheelPosition": "RIGHT",
       "hasHonkAndFlash": true,
+    ]
+  }
+
+  private func mockStatusResponse() -> [String: Any?] {
+    return [
+      "vin" : "ABC123",
+      "fuelLevel" : nil,
+      "oilLevel" : nil,
+      "batteryLevel" : [
+        "value" : 73,
+        "unit" : "PERCENT",
+        "unitTranslationKey" : "GRAY_SLICE_UNIT_PERCENT",
+        "unitTranslationKeyV2" : "TC.UNIT.PERCENT"
+      ],
+      "mileage" : [
+        "value" : 2195,
+        "unit" : "KILOMETERS",
+        "originalValue" : 2195,
+        "originalUnit" : "KILOMETERS",
+        "valueInKilometers" : 2195,
+        "unitTranslationKey" : "GRAY_SLICE_UNIT_KILOMETER",
+        "unitTranslationKeyV2" : "TC.UNIT.KILOMETER"
+      ],
+      "overallLockStatus" : "CLOSED_LOCKED",
+      "serviceIntervals" : [
+        "oilService" : [
+          "distance" : nil,
+          "time" : nil
+        ],
+        "inspection" : [
+          "distance" : [
+            "value" : -27842,
+            "unit" : "KILOMETERS",
+            "originalValue" : -27842,
+            "originalUnit" : "KILOMETERS",
+            "valueInKilometers" : -27842,
+            "unitTranslationKey" : "GRAY_SLICE_UNIT_KILOMETER",
+            "unitTranslationKeyV2" : "TC.UNIT.KILOMETER"
+          ],
+          "time" : [
+            "value" : -710,
+            "unit" : "DAYS",
+            "unitTranslationKey" : "GRAY_SLICE_UNIT_DAY",
+            "unitTranslationKeyV2" : "TC.UNIT.DAYS"
+          ]
+        ]
+      ],
+      "remainingRanges" : [
+        "conventionalRange" : [
+          "distance" : nil,
+          "engineType" : "UNSUPPORTED"
+        ],
+        "electricalRange" : [
+          "distance" : [
+            "value" : 294,
+            "unit" : "KILOMETERS",
+            "originalValue" : 294,
+            "originalUnit" : "KILOMETERS",
+            "valueInKilometers" : 294,
+            "unitTranslationKey" : "GRAY_SLICE_UNIT_KILOMETER",
+            "unitTranslationKeyV2" : "TC.UNIT.KILOMETER"
+          ],
+          "engineType" : "ELECTRIC"
+        ]
+      ]
     ]
   }
 

--- a/Tests/PorscheConnectTests/PorscheConnect+CarControlTests.swift
+++ b/Tests/PorscheConnectTests/PorscheConnect+CarControlTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Ambassador
+import XCTest
 
 @testable import PorscheConnect
 
@@ -432,7 +432,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAcceptedResponseVariantOne(result.remoteCommandAccepted!)
-    XCTAssertEqual(RemoteCommandAccepted.RemoteCommand.honkAndFlash, result.remoteCommandAccepted!.remoteCommand)
+    XCTAssertEqual(
+      RemoteCommandAccepted.RemoteCommand.honkAndFlash, result.remoteCommandAccepted!.remoteCommand)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -476,7 +477,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAcceptedResponseVariantOne(result.remoteCommandAccepted!)
-    XCTAssertEqual(RemoteCommandAccepted.RemoteCommand.honkAndFlash, result.remoteCommandAccepted!.remoteCommand)
+    XCTAssertEqual(
+      RemoteCommandAccepted.RemoteCommand.honkAndFlash, result.remoteCommandAccepted!.remoteCommand)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -516,13 +518,16 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: application))
 
-    let result = try! await connect.toggleDirectCharging(vehicle: vehicle, capabilities: capabilites)
+    let result = try! await connect.toggleDirectCharging(
+      vehicle: vehicle, capabilities: capabilites)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAcceptedResponseVariantTwo(result.remoteCommandAccepted!)
-    XCTAssertEqual(RemoteCommandAccepted.RemoteCommand.toggleDirectCharge, result.remoteCommandAccepted!.remoteCommand)
+    XCTAssertEqual(
+      RemoteCommandAccepted.RemoteCommand.toggleDirectCharge,
+      result.remoteCommandAccepted!.remoteCommand)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -538,13 +543,16 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: application))
 
-    let result = try! await connect.toggleDirectCharging(vehicle: vehicle, capabilities: capabilites, enable: false)
+    let result = try! await connect.toggleDirectCharging(
+      vehicle: vehicle, capabilities: capabilites, enable: false)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAcceptedResponseVariantTwo(result.remoteCommandAccepted!)
-    XCTAssertEqual(RemoteCommandAccepted.RemoteCommand.toggleDirectCharge, result.remoteCommandAccepted!.remoteCommand)
+    XCTAssertEqual(
+      RemoteCommandAccepted.RemoteCommand.toggleDirectCharge,
+      result.remoteCommandAccepted!.remoteCommand)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -583,7 +591,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.toggleDirectCharging(vehicle: vehicle, capabilities: capabilites, enable: false)
+      _ = try await connect.toggleDirectCharging(
+        vehicle: vehicle, capabilities: capabilites, enable: false)
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -612,7 +621,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAcceptedResponseVariantThree(result.remoteCommandAccepted!)
-    XCTAssertEqual(RemoteCommandAccepted.RemoteCommand.lock, result.remoteCommandAccepted!.remoteCommand)
+    XCTAssertEqual(
+      RemoteCommandAccepted.RemoteCommand.lock, result.remoteCommandAccepted!.remoteCommand)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -629,7 +639,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ =  try await connect.lock(vehicle: vehicle)
+      _ = try await connect.lock(vehicle: vehicle)
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -658,7 +668,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.remoteCommandAccepted)
     assertRemoteCommandAcceptedResponseVariantThree(result.remoteCommandAccepted!)
-    XCTAssertEqual(RemoteCommandAccepted.RemoteCommand.unlock, result.remoteCommandAccepted!.remoteCommand)
+    XCTAssertEqual(
+      RemoteCommandAccepted.RemoteCommand.unlock, result.remoteCommandAccepted!.remoteCommand)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
@@ -675,7 +686,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ =  try await connect.unlock(vehicle: vehicle, pin: "1234")
+      _ = try await connect.unlock(vehicle: vehicle, pin: "1234")
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -697,7 +708,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ =  try await connect.unlock(vehicle: vehicle, pin: "1234")
+      _ = try await connect.unlock(vehicle: vehicle, pin: "1234")
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -719,7 +730,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ =  try await connect.unlock(vehicle: vehicle, pin: "1234")
+      _ = try await connect.unlock(vehicle: vehicle, pin: "1234")
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -731,22 +742,28 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
   // MARK: - Private functions
 
-  private func assertRemoteCommandAcceptedResponseVariantOne(_ remoteCommandAccepted: RemoteCommandAccepted) {
+  private func assertRemoteCommandAcceptedResponseVariantOne(
+    _ remoteCommandAccepted: RemoteCommandAccepted
+  ) {
     XCTAssertEqual("123456789", remoteCommandAccepted.identifier)
     XCTAssertEqual("123456789", remoteCommandAccepted.id)
     XCTAssertNil(remoteCommandAccepted.requestId)
     XCTAssertEqual(
       ISO8601DateFormatter().date(from: "2022-12-27T13:19:23Z"), remoteCommandAccepted.lastUpdated)
   }
-  
-  private func assertRemoteCommandAcceptedResponseVariantTwo(_ remoteCommandAccepted: RemoteCommandAccepted) {
+
+  private func assertRemoteCommandAcceptedResponseVariantTwo(
+    _ remoteCommandAccepted: RemoteCommandAccepted
+  ) {
     XCTAssertEqual("123456789", remoteCommandAccepted.identifier)
     XCTAssertEqual("123456789", remoteCommandAccepted.requestId)
     XCTAssertNil(remoteCommandAccepted.id)
     XCTAssertNil(remoteCommandAccepted.lastUpdated)
   }
 
-  private func assertRemoteCommandAcceptedResponseVariantThree(_ remoteCommandAccepted: RemoteCommandAccepted) {
+  private func assertRemoteCommandAcceptedResponseVariantThree(
+    _ remoteCommandAccepted: RemoteCommandAccepted
+  ) {
     XCTAssertEqual("123456789", remoteCommandAccepted.identifier)
     XCTAssertEqual("123456789", remoteCommandAccepted.requestId)
     XCTAssertEqual("WP0ZZZY4MSA38703", remoteCommandAccepted.vin)

--- a/Tests/PorscheConnectTests/PorscheConnectTests.swift
+++ b/Tests/PorscheConnectTests/PorscheConnectTests.swift
@@ -32,25 +32,28 @@ final class PorscheConnectTests: BaseMockNetworkTestCase {
     let environment = Environment.germany
     XCTAssertNotNil(environment)
     XCTAssertEqual(environment.regionCode, "de/de_DE")
-    XCTAssertEqual(environment.languageCode, .german)
-    XCTAssertEqual(environment.countryCode, .germany)
+    XCTAssertEqual(environment.languageCode, LanguageCode.german.rawValue)
+    XCTAssertEqual(environment.countryCode, CountryCode.germany.rawValue)
   }
 
   func testEnvironmentCustom() {
     let environment = Environment(
-      countryCode: .unitedStates, languageCode: .english, regionCode: "us/en_US")
+      countryCode: CountryCode.unitedStates.rawValue,
+      languageCode: LanguageCode.english.rawValue,
+      regionCode: "us/en_US"
+    )
     XCTAssertNotNil(environment)
     XCTAssertEqual(environment.regionCode, "us/en_US")
-    XCTAssertEqual(environment.languageCode, .english)
-    XCTAssertEqual(environment.countryCode, .unitedStates)
+    XCTAssertEqual(environment.languageCode, LanguageCode.english.rawValue)
+    XCTAssertEqual(environment.countryCode, CountryCode.unitedStates.rawValue)
   }
 
   func testEnvironmentTest() {
     let environment = Environment.test
     XCTAssertNotNil(environment)
     XCTAssertEqual(environment.regionCode, "ie/en_IE")
-    XCTAssertEqual(environment.languageCode, .english)
-    XCTAssertEqual(environment.countryCode, .ireland)
+    XCTAssertEqual(environment.languageCode, LanguageCode.english.rawValue)
+    XCTAssertEqual(environment.countryCode, CountryCode.ireland.rawValue)
   }
 
   func testApplicationClientIdPortal() {


### PR DESCRIPTION
This is a stacked PR on top of https://github.com/driven-app/porsche-connect/pull/97

---

Locale inference attempts to use the system locale if it is one of the confirmed supported locales for the Porsche Connect APIs. If the system locale is not in our allowlist, then we fall back to Germany. The locale can also be explicitly overridden at the command line using the new `--locale` flag.