### PR TITLE
Remove loginToRetrieveCookies, as it does not appear to be needed.

### DIFF
--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -7,12 +7,6 @@ struct NetworkRoutes {
 
   // MARK: - Calculated properties
 
-  var loginAuthURL: URL {
-    return URL(
-      string:
-        "\(host("https://login.porsche.com"))/auth/api/v1/\(environment.regionCode)/public/login")!
-  }
-
   var apiAuthURL: URL {
     return URL(string: "\(host("https://login.porsche.com"))/as/authorization.oauth2")!
   }

--- a/Sources/PorscheConnect/PorscheConnect+Auth.swift
+++ b/Sources/PorscheConnect/PorscheConnect+Auth.swift
@@ -3,9 +3,6 @@ import Foundation
 extension PorscheConnect {
 
   public func auth(application: OAuthApplication) async throws -> OAuthToken {
-    let loginToRetrieveCookiesResponse = try await loginToRetrieveCookies()
-    guard loginToRetrieveCookiesResponse != nil else { throw PorscheConnectError.NoResult }
-
     let apiAuthCodeResult = try await getApiAuthCode(application: application)
     guard let codeVerifier = apiAuthCodeResult.codeVerifier,
       let code = apiAuthCodeResult.code
@@ -20,21 +17,6 @@ extension PorscheConnect {
     let token = OAuthToken(authResponse: porscheAuth)
     auths[application] = token
     return token
-  }
-
-  private func loginToRetrieveCookies() async throws -> HTTPURLResponse? {
-    let loginBody = buildLoginBody(username: username, password: password)
-    let result = try await networkClient.post(
-      String.self, url: networkRoutes.loginAuthURL,
-      body: buildPostFormBodyFrom(dictionary: loginBody), contentType: .form,
-      parseResponseBody: false)
-    if let statusCode = HttpStatusCode(rawValue: result.response.statusCode),
-      statusCode == .OK
-    {
-      AuthLogger.info("Login to retrieve cookies successful")
-    }
-
-    return result.response
   }
 
   private func getApiAuthCode(application: OAuthApplication) async throws -> (

--- a/Tests/PorscheConnectTests/Mock Server Backend/MockNetworkRoutes.swift
+++ b/Tests/PorscheConnectTests/Mock Server Backend/MockNetworkRoutes.swift
@@ -21,7 +21,6 @@ final class MockNetworkRoutes {
   private static let getLockUnlockRemoteCommandStatusPath =
     "service-vehicle/remote-lock-unlock/A1234/999/status"
 
-  private static let postLoginAuthPath = "/auth/api/v1/ie/en_IE/public/login"
   private static let postApiTokenPath = "/as/token.oauth2"
   private static let postFlashPath = "/service-vehicle/honk-and-flash/A1234/flash"
   private static let postHonkAndFlashPath = "/service-vehicle/honk-and-flash/A1234/honk-and-flash"
@@ -45,18 +44,6 @@ final class MockNetworkRoutes {
   func mockGetHelloWorldFailure(router: Router) {
     router[MockNetworkRoutes.getHelloWorldPath] = JSONResponse(
       statusCode: 401, statusMessage: "unauthorized")
-  }
-
-  // MARK: - Post Login Auth
-
-  func mockPostLoginAuthSuccessful(router: Router) {
-    router[MockNetworkRoutes.postLoginAuthPath] = DataResponse(
-      statusCode: 200, statusMessage: "ok", headers: [("Set-Cookie", "CIAM.status=mockValue")])
-  }
-
-  func mockPostLoginAuthFailure(router: Router) {
-    router[MockNetworkRoutes.postLoginAuthPath] = DataResponse(
-      statusCode: 400, statusMessage: "bad request")
   }
 
   // MARK: - Get Api Auth

--- a/Tests/PorscheConnectTests/Networking/NetworkRoutesTests.swift
+++ b/Tests/PorscheConnectTests/Networking/NetworkRoutesTests.swift
@@ -30,9 +30,6 @@ final class NetworkRoutesTests: XCTestCase {
   func testNetworkRoutesGermany() {
     let networkRoute = NetworkRoutes(environment: .germany)
     XCTAssertEqual(
-      URL(string: "https://login.porsche.com/auth/api/v1/de/de_DE/public/login")!,
-      networkRoute.loginAuthURL)
-    XCTAssertEqual(
       URL(string: "https://login.porsche.com/as/authorization.oauth2")!, networkRoute.apiAuthURL)
     XCTAssertEqual(
       URL(string: "https://login.porsche.com/as/token.oauth2")!, networkRoute.apiTokenURL)
@@ -86,9 +83,6 @@ final class NetworkRoutesTests: XCTestCase {
 
   func testNetworkRoutesTest() {
     let networkRoute = NetworkRoutes(environment: .test)
-    XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/auth/api/v1/ie/en_IE/public/login")!,
-      networkRoute.loginAuthURL)
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/as/authorization.oauth2")!,
       networkRoute.apiAuthURL)

--- a/Tests/PorscheConnectTests/Public/PorscheConnect+AuthTests.swift
+++ b/Tests/PorscheConnectTests/Public/PorscheConnect+AuthTests.swift
@@ -22,7 +22,6 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
   func testRequestTokenSuccessful() async {
     let application: OAuthApplication = .api
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
 
@@ -31,7 +30,6 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
     expectation.fulfill()
 
     XCTAssert(connect.authorized(application: application))
-    assertCookiesPresent()
 
     XCTAssertNotNil(porscheAuth)
     XCTAssertEqual("Kpjg2m1ZXd8GM0pvNIB3jogWd0o6", porscheAuth.accessToken)
@@ -57,7 +55,6 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
   func testRequestTokenFailureAtLoginToRetrieveCookies() async {
     let application: OAuthApplication = .api
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
     XCTAssertFalse(connect.authorized(application: application))
 
@@ -76,7 +73,6 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
   func testRequestTokenFailureAtGetApiAuthCode() async {
     let application: OAuthApplication = .api
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthFailure(router: router)
 
     XCTAssertFalse(connect.authorized(application: application))
@@ -86,7 +82,6 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
     } catch {
       expectation.fulfill()
       XCTAssertFalse(connect.authorized(application: application))
-      assertCookiesPresent()
     }
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
@@ -95,7 +90,6 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
   func testRequestTokenFailureAtGetApiAuthToken() async {
     let application: OAuthApplication = .api
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenFailure(router: router)
 
@@ -106,7 +100,6 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
     } catch {
       expectation.fulfill()
       XCTAssertFalse(connect.authorized(application: application))
-      assertCookiesPresent()
     }
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
@@ -117,14 +110,5 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
   private func assertCookiesNotPresent() {
     let cookies = HTTPCookieStorage.shared.cookies!
     XCTAssertEqual(0, cookies.count)
-  }
-
-  private func assertCookiesPresent() {
-    let cookies = HTTPCookieStorage.shared.cookies!
-    XCTAssertEqual(1, cookies.count)
-
-    let cookie = cookies.first!
-    XCTAssertEqual("CIAM.status", cookie.name)
-    XCTAssertEqual("mockValue", cookie.value)
   }
 }

--- a/Tests/PorscheConnectTests/Public/PorscheConnect+CarControlTests.swift
+++ b/Tests/PorscheConnectTests/Public/PorscheConnect+CarControlTests.swift
@@ -28,7 +28,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetSummarySuccessful(router: router)
@@ -82,7 +81,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
   func testSummaryAuthRequiredAuthFailure() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
     XCTAssertFalse(connect.authorized(application: application))
 
@@ -102,7 +100,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
   func testPositionAuthRequiredSuccessful() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetPositionSuccessful(router: router)
@@ -156,7 +153,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
   func testPositionAuthRequiredAuthFailure() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
     XCTAssertFalse(connect.authorized(application: application))
 
@@ -176,7 +172,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
   func testCapabilitiesAuthRequiredSuccessful() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetCapabilitiesSuccessful(router: router)
@@ -230,7 +225,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
   func testCapabilitiesAuthRequiredAuthFailure() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
     XCTAssertFalse(connect.authorized(application: application))
 
@@ -251,7 +245,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     connect.auths[.api] = nil
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetStatusSuccessful(router: router)
@@ -273,7 +266,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     connect.auths[.api] = nil
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
     XCTAssertFalse(connect.authorized(application: .api))
 
@@ -293,7 +285,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
   func testEmobilityAuthRequiredSuccessful() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetEmobilityNotChargingSuccessful(router: router)
@@ -398,7 +389,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
     XCTAssertFalse(connect.authorized(application: application))
 
@@ -419,7 +409,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostFlashSuccessful(router: router)
@@ -442,7 +431,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostFlashFailure(router: router)
@@ -464,7 +452,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostHonkAndFlashSuccessful(router: router)
@@ -487,7 +474,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostHonkAndFlashFailure(router: router)
@@ -511,7 +497,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostToggleDirectChargingOnSuccessful(router: router)
@@ -536,7 +521,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostToggleDirectChargingOffSuccessful(router: router)
@@ -561,7 +545,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostToggleDirectChargingOnFailure(router: router)
@@ -583,7 +566,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostToggleDirectChargingOffFailure(router: router)
@@ -608,7 +590,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostLockSuccessful(router: router)
@@ -631,7 +612,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostLockFailure(router: router)
@@ -655,7 +635,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetPostUnlockSuccessful(router: router)
@@ -678,7 +657,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetPostUnlockFailure(router: router)
@@ -700,7 +678,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetPostUnlockLockedError(router: router)
@@ -722,7 +699,6 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetPostUnlockIncorrectPinError(router: router)

--- a/Tests/PorscheConnectTests/Public/PorscheConnect+PortalTests.swift
+++ b/Tests/PorscheConnectTests/Public/PorscheConnect+PortalTests.swift
@@ -25,7 +25,6 @@ final class PorscheConnectPortalTests: BaseMockNetworkTestCase {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetVehiclesSuccessful(router: router)
@@ -81,7 +80,6 @@ final class PorscheConnectPortalTests: BaseMockNetworkTestCase {
   func testVehiclesAuthRequiredAuthFailure() async {
     connect.auths[application] = nil
     let expectation = expectation(description: "Network Expectation")
-    mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
     XCTAssertFalse(connect.authorized(application: application))
 

--- a/Tests/PorscheConnectTests/Public/PorscheConnect+RemoteCommandStatusTests.swift
+++ b/Tests/PorscheConnectTests/Public/PorscheConnect+RemoteCommandStatusTests.swift
@@ -27,7 +27,6 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     let remoteCommand = RemoteCommandAccepted(id: "999", lastUpdated: Date(), remoteCommand: .honkAndFlash)
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetHonkAndFlashRemoteCommandStatusInProgress(router: router)
@@ -49,7 +48,6 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     let remoteCommand = RemoteCommandAccepted(id: "999", lastUpdated: Date(), remoteCommand: .honkAndFlash)
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetHonkAndFlashRemoteCommandStatusSuccess(router: router)
@@ -71,7 +69,6 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     let remoteCommand = RemoteCommandAccepted(id: "999", lastUpdated: Date(), remoteCommand: .honkAndFlash)
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetHonkAndFlashRemoteCommandStatusFailure(router: router)
@@ -97,7 +94,6 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .toggleDirectCharge)
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetToggleDirectChargingRemoteCommandStatusInProgress(router: router)
@@ -119,7 +115,6 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .toggleDirectCharge)
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetToggleDirectChargingRemoteCommandStatusSuccess(router: router)
@@ -141,7 +136,6 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .toggleDirectCharge)
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetToggleDirectChargingRemoteCommandStatusFailure(router: router)
@@ -167,7 +161,6 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .lock)
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetLockUnlockRemoteCommandStatusInProgress(router: router)
@@ -189,7 +182,6 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .lock)
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetLockUnlockRemoteCommandStatusSuccess(router: router)
@@ -211,7 +203,6 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .lock)
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetLockUnlockRemoteCommandStatusFailure(router: router)
@@ -237,7 +228,6 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .lock)
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetLockUnlockRemoteCommandStatusInProgress(router: router)
@@ -259,7 +249,6 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .lock)
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetLockUnlockRemoteCommandStatusSuccess(router: router)
@@ -281,7 +270,6 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .lock)
     let expectation = expectation(description: "Network Expectation")
 
-    mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetLockUnlockRemoteCommandStatusFailure(router: router)


### PR DESCRIPTION
loginToRetrieveCookies doesn't actually set any cookies, and all API invocations appear to succeed without it. This reduces one roundtrip to the Porsche endpoints and speeds up the auth flow as a result.