### PR TITLE
Explicitly exit the show-capabilities command.

### DIFF
--- a/Sources/CommandLineTool/Command+ShowCapabilities.swift
+++ b/Sources/CommandLineTool/Command+ShowCapabilities.swift
@@ -35,8 +35,9 @@ extension Porsche {
         if let capabilities = result.capabilities {
           printCapabilities(capabilities)
         }
+        Porsche.ShowCapabilities.exit()
       } catch {
-        Porsche.ShowEmobility.exit(withError: error)
+        Porsche.ShowCapabilities.exit(withError: error)
       }
     }
 


### PR DESCRIPTION
This fixes the `zsh: trace trap` error that otherwise happens when running the command.