### PR TITLE
Fix authentication on watchOS.

### DIFF
--- a/Sources/PorscheConnect/PorscheConnect+Auth.swift
+++ b/Sources/PorscheConnect/PorscheConnect+Auth.swift
@@ -3,21 +3,23 @@ import Foundation
 extension PorscheConnect {
 
   public func auth(application: OAuthApplication) async throws -> OAuthToken {
-    let loginToRetrieveCookiesResponse = try await loginToRetrieveCookies()
-    guard loginToRetrieveCookiesResponse != nil else { throw PorscheConnectError.NoResult }
+    let token: OAuthToken = try await networkClient.interceptCookiesOnWatchOS {
+      let loginToRetrieveCookiesResponse = try await loginToRetrieveCookies()
+      guard loginToRetrieveCookiesResponse != nil else { throw PorscheConnectError.NoResult }
 
-    let apiAuthCodeResult = try await getApiAuthCode(application: application)
-    guard let codeVerifier = apiAuthCodeResult.codeVerifier,
-      let code = apiAuthCodeResult.code
-    else { throw PorscheConnectError.NoResult }
+      let apiAuthCodeResult = try await getApiAuthCode(application: application)
+      guard let codeVerifier = apiAuthCodeResult.codeVerifier,
+            let code = apiAuthCodeResult.code
+      else { throw PorscheConnectError.NoResult }
 
-    let apiTokenResult = try await getApiToken(
-      application: application, codeVerifier: codeVerifier, code: code)
-    guard let porscheAuth = apiTokenResult.data,
-      apiTokenResult.response != nil
-    else { throw PorscheConnectError.NoResult }
+      let apiTokenResult = try await getApiToken(
+        application: application, codeVerifier: codeVerifier, code: code)
+      guard let porscheAuth = apiTokenResult.data,
+            apiTokenResult.response != nil
+      else { throw PorscheConnectError.NoResult }
 
-    let token = OAuthToken(authResponse: porscheAuth)
+      return OAuthToken(authResponse: porscheAuth)
+    }
     auths[application] = token
     return token
   }

--- a/Sources/PorscheConnect/watchOS/FixWatchOSCookiesURLSessionDataDelegate.swift
+++ b/Sources/PorscheConnect/watchOS/FixWatchOSCookiesURLSessionDataDelegate.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// On watchOS, cookies are not saved and sent during HTTP redirect chains. This causes the authentication flow
+/// to fail due to a lack of necessary cookies when attempting to fetch the API token.
+/// To work around this, this delegate handles all redirects and manually tracks set cookies and injects those cookies
+/// into subsequent requests.
+/// See https://developer.apple.com/forums/thread/43818 for related bugs.
+///
+/// Note that this delegate is only required during the auth flow.
+final class FixWatchOSCookiesURLSessionDataDelegate: NSObject, URLSessionDataDelegate {
+  /// When enabled, cookies will be stored and injected into redirect requests.
+  /// Changing this value will reset the cookie storage.
+  var interceptCookies = false {
+    didSet {
+      cookieStorage.removeAll()
+    }
+  }
+
+  private var cookieStorage: [String: HTTPCookie] = [:]
+
+  // MARK: - URLSessionDataDelegate
+
+  func urlSession(_ session: URLSession,
+                  task: URLSessionTask,
+                  willPerformHTTPRedirection response: HTTPURLResponse,
+                  newRequest request: URLRequest) async -> URLRequest? {
+    if !interceptCookies {
+      return request
+    }
+    guard let responseUrl = response.url else {
+      // Nothing for us to do here. Pass-through.
+      return request
+    }
+    let cookies = HTTPCookie.cookies(
+      withResponseHeaderFields: response.allHeaderFields as! [String: String],
+      for: responseUrl
+    )
+    for cookie in cookies {
+      let key = cookie.domain + cookie.path + cookie.name
+      // It's important that we expire cookies as part of the auth flow. In some cases, redirects
+      // will explicitly kill a cookie (e.g. CIAM.m) by setting the expiration date to the epoch.
+      if let expiresDate = cookie.expiresDate, expiresDate < Date() {
+        cookieStorage[key] = nil
+        continue
+      }
+      cookieStorage[key] = cookie
+    }
+
+    return injectCookies(into: request)
+  }
+
+  func injectCookies(into request: URLRequest) -> URLRequest {
+    if !interceptCookies {
+      return request
+    }
+    var mutableRequest = request
+    // Note that `addValue` can *not* be used here for an array of cookies because it creates a
+    // malformed cookie string using `,` delimiters instead of required `; ` delimiters. We build
+    // the cookie parameter by hand here to avoid that issue.
+    mutableRequest.setValue(
+      cookieStorage.values
+        .map { "\($0.name)=\($0.value)" }
+        .joined(separator: "; "),
+      forHTTPHeaderField: "Cookie")
+    return mutableRequest
+  }
+}

--- a/Tests/PorscheConnectTests/watchOS/FixWatchOSCookiesURLSessionDataDelegateTests.swift
+++ b/Tests/PorscheConnectTests/watchOS/FixWatchOSCookiesURLSessionDataDelegateTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import PorscheConnect
+
+final class FixWatchOSCookiesURLSessionDataDelegateTests: XCTestCase {
+
+  var delegate: FixWatchOSCookiesURLSessionDataDelegate!
+  override func setUpWithError() throws {
+    delegate = FixWatchOSCookiesURLSessionDataDelegate()
+  }
+
+  override func tearDownWithError() throws {
+    delegate = nil
+  }
+
+  // MARK: - Defaults
+
+  func testInterceptCookiesIsOffByDefault() throws {
+    let delegate = FixWatchOSCookiesURLSessionDataDelegate()
+    XCTAssertFalse(delegate.interceptCookies)
+  }
+
+  // MARK: - Cookie injection
+
+  func testCookieGetsInjectedWhenInterceptCookiesIsOn() async throws {
+    // Given
+    let delegate = FixWatchOSCookiesURLSessionDataDelegate()
+    delegate.interceptCookies = true
+
+    // When
+    let configuration = URLSessionConfiguration.default
+    let session = URLSession(configuration: configuration)
+    let url = URL(string: "https://login.porsche.com/")!
+    let request = URLRequest(url: url)
+    let task = session.dataTask(with: request)
+    let response = HTTPURLResponse(url: url, statusCode: 302, httpVersion: nil, headerFields: [
+      "Set-Cookie": "CIAM.status=loggedinuntil12345; Domain=.porsche.com; Path=/; Secure; SameSite=None"
+    ])!
+    let newRequest = await delegate.urlSession(session, task: task, willPerformHTTPRedirection: response, newRequest: request)
+
+    // Then
+    let cookie = try XCTUnwrap(newRequest?.allHTTPHeaderFields?["Cookie"])
+    XCTAssertEqual(cookie, "CIAM.status=loggedinuntil12345")
+  }
+
+  func testCookieDoesNotGetInjectedWhenInterceptCookiesIsOff() async throws {
+    // Given
+    let delegate = FixWatchOSCookiesURLSessionDataDelegate()
+    delegate.interceptCookies = false
+
+    // When
+    let configuration = URLSessionConfiguration.default
+    let session = URLSession(configuration: configuration)
+    let url = URL(string: "https://login.porsche.com/")!
+    let request = URLRequest(url: url)
+    let task = session.dataTask(with: request)
+    let response = HTTPURLResponse(url: url, statusCode: 302, httpVersion: nil, headerFields: [
+      "Set-Cookie": "CIAM.status=loggedinuntil12345; Domain=.porsche.com; Path=/; Secure; SameSite=None"
+    ])!
+    let newRequest = await delegate.urlSession(session, task: task, willPerformHTTPRedirection: response, newRequest: request)
+
+    // Then
+    XCTAssertNil(newRequest?.allHTTPHeaderFields?["Cookie"])
+  }
+}


### PR DESCRIPTION
On watchOS, HTTPCookieStorage does not capture and propagate cookies received during HTTP redirections. This causes the authentication flow to fail because it relies on cookies being set and persisted across several redirect hops.

This commit fixes this bug by implementing a delegate on the URLSession and manually observing all Set-Cookie headers, storing those cookies, and then injecting those cookies into subsequent requests.

Related: https://github.com/AFNetworking/AFNetworking/issues/3686