### PR TITLE
Make public initializers for VehiclePicture and VehicleAttribute.

### DIFF
--- a/Sources/PorscheConnect/Models/Vehicle.swift
+++ b/Sources/PorscheConnect/Models/Vehicle.swift
@@ -26,6 +26,10 @@ public struct Vehicle: Codable {
   // MARK: -
 
   public struct VehicleAttribute: Codable {
+    public init(name: String, value: String) {
+      self.name = name
+      self.value = value
+    }
 
     // MARK: Properties
 
@@ -36,6 +40,23 @@ public struct Vehicle: Codable {
   // MARK: -
 
   public struct VehiclePicture: Codable {
+    public init(
+      url: URL,
+      view: String,
+      size: Int,
+      width: Int,
+      height: Int,
+      transparent: Bool,
+      placeholder: String? = nil
+    ) {
+      self.url = url
+      self.view = view
+      self.size = size
+      self.width = width
+      self.height = height
+      self.transparent = transparent
+      self.placeholder = placeholder
+    }
 
     // MARK: Properties
 


### PR DESCRIPTION
This makes it possible to create, from outside of the PorscheConnect library, instances of the Vehicle type with pictures and/or attributes. This is particularly handy for SwiftUI previews that might consume the Vehicle type.