### PR TITLE
Add a StatusFormatter.

### DIFF
--- a/Sources/PorscheConnect/Models/Formatters/StatusFormatter.swift
+++ b/Sources/PorscheConnect/Models/Formatters/StatusFormatter.swift
@@ -4,6 +4,8 @@ import Foundation
 ///
 /// All properties will be formatted based on the provided locale.
 public final class StatusFormatter {
+  public init() {}
+
   /// The locale to use for all textual representations.
   public var locale: Locale = Locale.current
 

--- a/Sources/PorscheConnect/Models/Formatters/StatusFormatter.swift
+++ b/Sources/PorscheConnect/Models/Formatters/StatusFormatter.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// A formatter that converts Status properties into their textual representations.
+///
+/// All properties will be formatted based on the provided locale.
+public final class StatusFormatter {
+  /// The locale to use for all textual representations.
+  public var locale: Locale = Locale.current
+
+  /// The style used when creating a textual representation of distance (e.g. miles or kilometers).
+  public var distanceUnitStyle: MeasurementFormatter.UnitStyle = .medium
+
+  /// Returns a textual representation of the vehicle's battery charge.
+  public func batteryLevel(from status: Status) -> String {
+    return formatted(genericValue: status.batteryLevel, scalar: 0.01)
+  }
+
+  /// Returns a textual representation of the vehicle's mileage.
+  public func mileage(from status: Status) -> String {
+    return formatted(distance: status.mileage)
+  }
+
+  /// Returns a textual representation of the vehicle's mileage.
+  public func lockedStatus(from status: Status) -> String {
+    return formatted(distance: status.mileage)
+  }
+
+  /// Returns a textual representation of the vehicle's remaining range.
+  public func electricalRange(from status: Status) -> String? {
+    if let electricalRangeDistance = status.remainingRanges.electricalRange.distance {
+      return formatted(distance: electricalRangeDistance)
+    }
+    return nil
+  }
+}
+
+// MARK: - Private helper methods
+
+extension StatusFormatter {
+  /// Returns a numerical value formatted using the value's unit and the formatter's locale.
+  private func formatted(genericValue: Status.GenericValue, scalar: Double = 1) -> String {
+    let value = Double(genericValue.value) * scalar
+    switch genericValue.unit {
+    case "PERCENT":
+      let formatter = NumberFormatter()
+      formatter.locale = locale
+      formatter.numberStyle = .percent
+      formatter.maximumFractionDigits = 0
+      return formatter.string(from: value as NSNumber)!
+    case "DAYS":
+      let formatter = DateFormatter()
+      formatter.locale = locale
+      formatter.dateStyle = .medium
+      formatter.timeStyle = .none
+      formatter.formattingContext = .middleOfSentence
+      let secondsPerDay: Double = 24 * 60 * 60
+      return formatter.string(from: Date(timeIntervalSinceNow: value * secondsPerDay))
+    default:
+      return "\(value) \(genericValue.unit)"
+    }
+  }
+
+  private func formatted(distance: Status.Distance, scalar: Double = 1) -> String {
+    let formatter = MeasurementFormatter()
+    formatter.locale = locale
+    formatter.unitStyle = distanceUnitStyle
+    formatter.unitOptions = []
+    formatter.locale = locale
+    formatter.numberFormatter.maximumFractionDigits = 0
+    let value = distance.value * scalar
+    let unit: UnitLength
+    switch distance.unit {
+    case "KILOMETERS":
+      unit = .kilometers
+    case "MILES":
+      unit = .miles
+    default:
+      return "\(value)"
+    }
+    return formatter.string(from: Measurement(value: value, unit: unit))
+  }
+}

--- a/Tests/PorscheConnectTests/Models/Formatters/StatusFormatterTests.swift
+++ b/Tests/PorscheConnectTests/Models/Formatters/StatusFormatterTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+
+@testable import PorscheConnect
+
+final class StatusFormatterTests: XCTestCase {
+
+  var formatter: StatusFormatter!
+  override func setUp() {
+    formatter = StatusFormatter()
+  }
+
+  override func tearDown() {
+    formatter = nil
+  }
+
+  // MARK: - Defaults
+
+  func testDefaultLocaleIsCurrent() {
+    XCTAssertEqual(formatter.locale, .current)
+  }
+
+  // MARK: - Specific locales
+
+  func testAmericanEnglishFormatting() {
+    formatter.locale = Locale(identifier: "en_US")
+    XCTAssertEqual(formatter.batteryLevel(from: templateStatus), "12%")
+    XCTAssertEqual(formatter.mileage(from: templateStatus), "1,364 mi")
+    XCTAssertEqual(formatter.electricalRange(from: templateStatus), "183 mi")
+  }
+
+  func testCanadianEnglishFormatting() {
+    formatter.locale = Locale(identifier: "en_CA")
+    XCTAssertEqual(formatter.batteryLevel(from: templateStatus), "12%")
+    XCTAssertEqual(formatter.mileage(from: templateStatus), "2,195 km")
+    XCTAssertEqual(formatter.electricalRange(from: templateStatus), "294 km")
+  }
+
+  func testUnitedKingdomEnglishFormatting() {
+    formatter.locale = Locale(identifier: "en_GB")
+    XCTAssertEqual(formatter.batteryLevel(from: templateStatus), "12%")
+    XCTAssertEqual(formatter.mileage(from: templateStatus), "1,364 mi")
+    XCTAssertEqual(formatter.electricalRange(from: templateStatus), "183 mi")
+  }
+
+  func testChineseFormatting() {
+    formatter.locale = Locale(identifier: "zh_CN")
+    XCTAssertEqual(formatter.batteryLevel(from: templateStatus), "12%")
+    XCTAssertEqual(formatter.mileage(from: templateStatus), "2,195公里")
+    XCTAssertEqual(formatter.electricalRange(from: templateStatus), "294公里")
+  }
+
+  func testGermanFormatting() {
+    formatter.locale = Locale(identifier: "de_DE")
+    XCTAssertEqual(formatter.batteryLevel(from: templateStatus), "12 %")
+    XCTAssertEqual(formatter.mileage(from: templateStatus), "2.195 km")
+    XCTAssertEqual(formatter.electricalRange(from: templateStatus), "294 km")
+  }
+}
+
+private let templateStatus = Status(
+  vin: "abc123",
+  batteryLevel: Status.GenericValue(
+    value: 12,
+    unit: "PERCENT",
+    unitTranslationKey: "GRAY_SLICE_UNIT_PERCENT",
+    unitTranslationKeyV2: "TC.UNIT.PERCENT"),
+  mileage: Status.Distance(
+    value: 2195,
+    unit: "KILOMETERS",
+    originalValue: 2195,
+    originalUnit: "KILOMETERS",
+    valueInKilometers: 2195,
+    unitTranslationKey: "GRAY_SLICE_UNIT_KILOMETER",
+    unitTranslationKeyV2: "TC.UNIT.KILOMETER"),
+  overallLockStatus: "CLOSED_LOCKED",
+  serviceIntervals: Status.ServiceIntervals(
+    oilService: Status.ServiceIntervals.OilService(),
+    inspection: Status.ServiceIntervals.Inspection(
+      distance: Status.Distance(
+        value: -27842,
+        unit: "KILOMETERS",
+        originalValue: -27842,
+        originalUnit: "KILOMETERS",
+        valueInKilometers: -27842,
+        unitTranslationKey: "GRAY_SLICE_UNIT_KILOMETER",
+        unitTranslationKeyV2: "TC.UNIT.KILOMETER"
+      ),
+      time: Status.GenericValue(
+        value: -710,
+        unit: "DAYS",
+        unitTranslationKey: "GRAY_SLICE_UNIT_DAY",
+        unitTranslationKeyV2: "TC.UNIT.DAYS"
+      )
+    )
+  ),
+  remainingRanges: Status.RemainingRanges(
+    conventionalRange: Status.RemainingRanges.Range(
+      distance: nil,
+      engineType: "UNSUPPORTED"
+    ),
+    electricalRange: Status.RemainingRanges.Range(
+      distance: Status.Distance(
+        value: 294,
+        unit: "KILOMETERS",
+        originalValue: 294,
+        originalUnit: "KILOMETERS",
+        valueInKilometers: 294,
+        unitTranslationKey: "GRAY_SLICE_UNIT_KILOMETER",
+        unitTranslationKeyV2: "TC.UNIT.KILOMETER"
+      ),
+      engineType: "ELECTRIC"
+    )
+  )
+)


### PR DESCRIPTION
This type makes it easier to create localized, textual representations of the various Status properties.