### PR TITLE
Make Status.GenericValue.value a Double instead of an Int.

### DIFF
--- a/Sources/PorscheConnect/Models/Status.swift
+++ b/Sources/PorscheConnect/Models/Status.swift
@@ -52,7 +52,7 @@ public struct Status: Codable {
   }
 
   public struct GenericValue: Codable {
-    public let value: Int
+    public let value: Double
     public let unit: String
     public let unitTranslationKey: String
     public let unitTranslationKeyV2: String


### PR DESCRIPTION
Though the values are most typically integers, using a Double will protect against unexpected loss of precision if that changes in the future.