### PR TITLE
Fix parsing error with Emobility.

### DIFF
--- a/Sources/PorscheConnect/Models/Emobility.swift
+++ b/Sources/PorscheConnect/Models/Emobility.swift
@@ -115,13 +115,13 @@ public struct Emobility: Codable {
     /// - `OFF`
     public let climatisationState: String
     public let remainingClimatisationTime: String?  // TBD when set
-    public let targetTemperature: String
+    public let targetTemperature: String?
     /// Can be any of:
     /// - `false`
-    public let climatisationWithoutHVpower: String
+    public let climatisationWithoutHVpower: String?
     /// Can be any of:
     /// - `electric`
-    public let heaterSource: String
+    public let heaterSource: String?
   }
 
   // MARK: -

--- a/Sources/PorscheConnect/Models/Emobility.swift
+++ b/Sources/PorscheConnect/Models/Emobility.swift
@@ -8,6 +8,8 @@ public struct Emobility: Codable {
   public let batteryChargeStatus: BatteryChargeStatus
   public let directCharge: DirectCharge
   public let directClimatisation: DirectClimatisation
+  /// Can be any of:
+  /// - `INSTANT_CHARGING`
   public let chargingStatus: String
   public let chargingProfiles: ChargingProfiles
   public let climateTimer: String?  // TBD when set
@@ -19,13 +21,29 @@ public struct Emobility: Codable {
 
     // MARK: Properties
 
+    /// Can be any of:
+    /// - `CONNECTED`
     public let plugState: String
+    /// Can be any of:
+    /// - `LOCKED`
     public let lockState: String
+    /// Can be any of:
+    /// - `CHARGING`
     public let chargingState: String
+    /// Can be any of:
+    /// - `IMMEDIATE`
     public let chargingReason: String
+    /// Can be any of:
+    /// - `AVAILABLE`
     public let externalPowerSupplyState: String
+    /// Can be any of:
+    /// - `GREEN`
     public let ledColor: String
+    /// Can be any of:
+    /// - `BLINK`
     public let ledState: String
+    /// Can be any of:
+    /// - `AC`
     public let chargingMode: String
     public let stateOfChargeInPercentage: Int
     public let remainingChargeTimeUntil100PercentInMinutes: Int?
@@ -43,9 +61,12 @@ public struct Emobility: Codable {
 
       // MARK: Properties
 
-      public let value: Int
+      public let value: Double
+      /// Can be any of:
+      /// - `MILES`
+      /// - `KILOMETERS`
       public let unit: String
-      public let originalValue: Int
+      public let originalValue: Double
       public let originalUnit: String
       public let valueInKilometers: Int
       public let unitTranslationKey: String
@@ -58,8 +79,10 @@ public struct Emobility: Codable {
       // MARK: Properties
 
       public let value: Double
+      /// Can be any of:
+      /// - `MILES_PER_MIN`
       public let unit: String
-      public let valueInKmPerHour: Int
+      public let valueInKmPerHour: Double
       public let unitTranslationKey: String  // "EC.COMMON.UNIT.KM_PER_MIN"
     }
   }
@@ -80,8 +103,17 @@ public struct Emobility: Codable {
 
     // MARK: Properties
 
+    /// Can be any of:
+    /// - `OFF`
     public let climatisationState: String
     public let remainingClimatisationTime: String?  // TBD when set
+    public let targetTemperature: String
+    /// Can be any of:
+    /// - `false`
+    public let climatisationWithoutHVpower: String
+    /// Can be any of:
+    /// - `electric`
+    public let heaterSource: String
   }
 
   // MARK: -
@@ -115,7 +147,9 @@ public struct Emobility: Codable {
       public let minimumChargeLevel: Int
       public let smartChargingEnabled: Bool
       public let preferredChargingEnabled: Bool
+      /// In the format "HH:MM"
       public let preferredChargingTimeStart: String
+      /// In the format "HH:MM"
       public let preferredChargingTimeEnd: String
     }
 

--- a/Sources/PorscheConnect/Models/Emobility.swift
+++ b/Sources/PorscheConnect/Models/Emobility.swift
@@ -23,29 +23,37 @@ public struct Emobility: Codable {
 
     /// Can be any of:
     /// - `CONNECTED`
+    /// - `DISCONNECTED`
     public let plugState: String
     /// Can be any of:
     /// - `LOCKED`
+    /// - `UNLOCKED`
     public let lockState: String
     /// Can be any of:
     /// - `CHARGING`
+    /// - `OFF`-
     public let chargingState: String
     /// Can be any of:
     /// - `IMMEDIATE`
+    /// - `INVALID`
     public let chargingReason: String
     /// Can be any of:
     /// - `AVAILABLE`
+    /// - `UNAVAILABLE`
     public let externalPowerSupplyState: String
     /// Can be any of:
     /// - `GREEN`
+    /// - `NONE`
     public let ledColor: String
     /// Can be any of:
     /// - `BLINK`
+    /// - `OFF`
     public let ledState: String
     /// Can be any of:
     /// - `AC`
+    /// - `OFF`
     public let chargingMode: String
-    public let stateOfChargeInPercentage: Int
+    public let stateOfChargeInPercentage: Double
     public let remainingChargeTimeUntil100PercentInMinutes: Int?
     public let remainingERange: RemainingERange
     public let remainingCRange: String?  // TBD while charging


### PR DESCRIPTION
Some of the values that were typed as Ints were actually Doubles, causing the decoder to fail when the values had floating point values.

Also provided some basic documentation of some of the known values.