### PR TITLE
Mark some Capabilities parameters as optional.

### DIFF
--- a/Sources/CommandLineTool/Command+ShowCapabilities.swift
+++ b/Sources/CommandLineTool/Command+ShowCapabilities.swift
@@ -43,7 +43,7 @@ extension Porsche {
 
     private func printCapabilities(_ capabilities: Capabilities) {
       let output = NSLocalizedString(
-        "Display parking brake: \(capabilities.displayParkingBrake.displayString); Needs SPIN: \(capabilities.needsSPIN.displayString); Has RDK: \(capabilities.hasRDK.displayString); Engine Type: \(capabilities.engineType); Car Model: \(capabilities.carModel); Front Seat Heating: \(capabilities.heatingCapabilities.frontSeatHeatingAvailable.displayString); Rear Seat Heating: \(capabilities.heatingCapabilities.rearSeatHeatingAvailable.displayString); Steering Wheel Position: \(capabilities.steeringWheelPosition); Honk & Flash: \(capabilities.hasHonkAndFlash.displayString)",
+        "Display parking brake: \(capabilities.displayParkingBrake.displayString); Needs SPIN: \(capabilities.needsSPIN.displayString); Has RDK: \(capabilities.hasRDK.displayString); Engine Type: \(capabilities.engineType); Car Model: \(capabilities.carModel); Front Seat Heating: \(capabilities.heatingCapabilities.frontSeatHeatingAvailable.displayString); Rear Seat Heating: \(capabilities.heatingCapabilities.rearSeatHeatingAvailable.displayString); Steering Wheel Position: \(capabilities.steeringWheelPosition); Honk & Flash: \(capabilities.hasHonkAndFlash?.displayString ?? "Not currently available")",
         comment: "")
       print(output)
     }

--- a/Sources/PorscheConnect/Models/Capabilities.swift
+++ b/Sources/PorscheConnect/Models/Capabilities.swift
@@ -9,10 +9,10 @@ public struct Capabilities: Codable {
   public let hasRDK: Bool
   public let engineType: String
   public let carModel: String
-  public let onlineRemoteUpdateStatus: OnlineRemoteUpdateStatus
+  public let onlineRemoteUpdateStatus: OnlineRemoteUpdateStatus?
   public let heatingCapabilities: HeatingCapabilities
   public let steeringWheelPosition: String
-  public let hasHonkAndFlash: Bool
+  public let hasHonkAndFlash: Bool?
 
   // MARK: -
 

--- a/Tests/PorscheConnectTests/Models/Models+CapabilitiesTests.swift
+++ b/Tests/PorscheConnectTests/Models/Models+CapabilitiesTests.swift
@@ -13,9 +13,9 @@ final class ModelsCapabilitiesTests: XCTestCase {
     XCTAssertFalse(capabilities.displayParkingBrake)
     XCTAssertFalse(capabilities.needsSPIN)
     XCTAssertFalse(capabilities.hasRDK)
-    XCTAssertFalse(capabilities.hasHonkAndFlash)
-    XCTAssertTrue(capabilities.onlineRemoteUpdateStatus.active)
-    XCTAssertTrue(capabilities.onlineRemoteUpdateStatus.editableByUser)
+    XCTAssertEqual(capabilities.hasHonkAndFlash, false)
+    XCTAssertEqual(capabilities.onlineRemoteUpdateStatus?.active, true)
+    XCTAssertEqual(capabilities.onlineRemoteUpdateStatus?.editableByUser, true)
     XCTAssertTrue(capabilities.heatingCapabilities.frontSeatHeatingAvailable)
     XCTAssertFalse(capabilities.heatingCapabilities.rearSeatHeatingAvailable)
   }
@@ -31,12 +31,12 @@ final class ModelsCapabilitiesTests: XCTestCase {
     XCTAssertTrue(capabilities.hasRDK)
     XCTAssertEqual("BEV", capabilities.engineType)
     XCTAssertEqual("J1", capabilities.carModel)
-    XCTAssertTrue(capabilities.onlineRemoteUpdateStatus.editableByUser)
-    XCTAssertTrue(capabilities.onlineRemoteUpdateStatus.active)
+    XCTAssertEqual(capabilities.onlineRemoteUpdateStatus?.active, true)
+    XCTAssertEqual(capabilities.onlineRemoteUpdateStatus?.editableByUser, true)
     XCTAssertTrue(capabilities.heatingCapabilities.frontSeatHeatingAvailable)
     XCTAssertFalse(capabilities.heatingCapabilities.rearSeatHeatingAvailable)
     XCTAssertEqual("RIGHT", capabilities.steeringWheelPosition)
-    XCTAssertTrue(capabilities.hasHonkAndFlash)
+    XCTAssertEqual(capabilities.hasHonkAndFlash, true)
   }
 
   // MARK: - Private functions

--- a/Tests/PorscheConnectTests/Public/PorscheConnect+CarControlTests.swift
+++ b/Tests/PorscheConnectTests/Public/PorscheConnect+CarControlTests.swift
@@ -794,12 +794,12 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertTrue(capabilities.hasRDK)
     XCTAssertEqual("BEV", capabilities.engineType)
     XCTAssertEqual("J1", capabilities.carModel)
-    XCTAssertTrue(capabilities.onlineRemoteUpdateStatus.editableByUser)
-    XCTAssertTrue(capabilities.onlineRemoteUpdateStatus.active)
+    XCTAssertEqual(capabilities.onlineRemoteUpdateStatus?.editableByUser, true)
+    XCTAssertEqual(capabilities.onlineRemoteUpdateStatus?.active, true)
     XCTAssertTrue(capabilities.heatingCapabilities.frontSeatHeatingAvailable)
     XCTAssertFalse(capabilities.heatingCapabilities.rearSeatHeatingAvailable)
     XCTAssertEqual("RIGHT", capabilities.steeringWheelPosition)
-    XCTAssertTrue(capabilities.hasHonkAndFlash)
+    XCTAssertEqual(capabilities.hasHonkAndFlash, true)
   }
 
   private func assertStatus(_ status: Status) {


### PR DESCRIPTION
Specifically, it seems that onlineRemoteUpdateStatus and hasHonkAndFlash aren't always guaranteed to be returned by the API.