### PR TITLE
[breaking] Simplify all vehicle API calls by accepting a VIN directly instead of a Vehicle instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To get a summary for a vehicle. This call will return a `Summary` struct.
 
 ```swift
 try {
-  let result = porscheConnect.summary(vehicle: vehicle)
+  let result = porscheConnect.summary(vin: vehicle.vin)
   if let summary = result.summary {
     // Do something with the summary
   }
@@ -115,7 +115,7 @@ To get last reported position for a vehicle. This call will return a `Position` 
 
 ```swift
 try {
-  let result = porscheConnect.position(vehicle: vehicle)
+  let result = porscheConnect.position(vin: vehicle.vin)
   if let position = result.position {
     // Do something with the position
   }
@@ -130,7 +130,7 @@ To get capabilities for a vehicle. This call will return a `Capabilities` struct
 
 ```swift
 try {
-  let result = porscheConnect.capabilities(vehicle: vehicle)
+  let result = porscheConnect.capabilities(vin: vehicle.vin)
   if let capabilities = result.capabilities {
     // Do something with the capabilities
   }
@@ -145,7 +145,7 @@ If the vehicle is a plug-in hybrid (PHEV) or a battery electric vehicle (BEV) th
 
 ```swift
 try {
-  let result = porscheConnect.emobility(vehicle: vehicle, capabilities: capabilities)
+  let result = porscheConnect.emobility(vin: vehicle.vin, capabilities: capabilities)
   if let emobility = result.emobility {
     // Do something with the emobility
   }
@@ -160,7 +160,7 @@ To get the status for a vehicle. This call will return a `Status` struct. This s
 
 ```swift
 try {
-  let result = porscheConnect.status(vehicle: vehicle)
+  let result = porscheConnect.status(vin: vehicle.vin)
   if let status = result.status {
     // Do something with the status
   }
@@ -175,7 +175,7 @@ To ask the vehicle to flash its indicators and optionally honk the horn. This ca
 
 ```swift
 try {
-  let result = porscheConnect.flash(vehicle: vehicle, andHorn: true)
+  let result = porscheConnect.flash(vin: vehicle.vin, andHorn: true)
   if let remoteCommandAccepted = result.remoteCommandAccepted {
     // Do something with the remote command
   }
@@ -192,7 +192,7 @@ Passing in a capabilites paramater is not required to determine the status of a 
 
 ```swift
 try {
-  let result = porscheConnect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommandAccepted)
+  let result = porscheConnect.checkStatus(vin: vehicle.vin, remoteCommand: remoteCommandAccepted)
   if let remoteCommandStatus = result.remoteCommand {
     // Do something with the remote command status
   }
@@ -211,7 +211,7 @@ Passing in a vehicles `Capabilites` is optional – if none is passed in, the li
 
 ```swift
 try {
-  let result = porscheConnect.toggleDirectCharging(vehicle: vehicle, capabilities: capabilities, enable: false)
+  let result = porscheConnect.toggleDirectCharging(vin: vehicle.vin, capabilities: capabilities, enable: false)
   if let remoteCommandAccepted = result.remoteCommandAccepted {
     // Do something with the remote command
   }
@@ -228,7 +228,7 @@ Passing in a vehicles `Capabilites` is optional – if none is passed in, the li
 
 ```swift
 try {
-  let result = porscheConnect.checkStatus(vehicle: vehicle, capabilities: capabilities, remoteCommand: remoteCommandAccepted)
+  let result = porscheConnect.checkStatus(vin: vehicle.vin, capabilities: capabilities, remoteCommand: remoteCommandAccepted)
   if let remoteCommandStatus = result.remoteCommand {
     // Do something with the remote command status
   }
@@ -245,7 +245,7 @@ The `enable` parameter is optional and defaults to true.
 
 ```swift
 try {
-  let result = porscheConnect.toggleClimatisation(vehicle: vehicle, enable: false)
+  let result = porscheConnect.toggleClimatisation(vin: vehicle.vin, enable: false)
   if let remoteCommandAccepted = result.remoteCommandAccepted {
     // Do something with the remote command
   }
@@ -260,7 +260,7 @@ The `status` is mapped to a strongly typed enum that can be retrieved by accessi
 
 ```swift
 try {
-  let result = porscheConnect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommandAccepted)
+  let result = porscheConnect.checkStatus(vin: vehicle.vin, remoteCommand: remoteCommandAccepted)
   if let remoteCommandStatus = result.remoteCommand {
     // Do something with the remote command status
   }
@@ -277,7 +277,7 @@ Make sure that there are no vehicle keys, persons or animals in the vehicle.
 
 ```swift
 try {
-  let result = porscheConnect.lock(vehicle: vehicle)
+  let result = porscheConnect.lock(vin: vehicle.vin)
   if let remoteCommandAccepted = result.remoteCommandAccepted {
     // Do something with the remote command
   }
@@ -294,7 +294,7 @@ Passing in a capabilites paramater is not required to determine the status of a 
 
 ```swift
 try {
-  let result = porscheConnect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommandAccepted)
+  let result = porscheConnect.checkStatus(vin: vehicle.vin, remoteCommand: remoteCommandAccepted)
   if let remoteCommandStatus = result.remoteCommand {
     // Do something with the remote command status
   }
@@ -309,7 +309,7 @@ To ask the vehicle to remote unlock. As this action impacts the security of the 
 
 ```swift
 try {
-  let result = porscheConnect.unlock(vehicle: vehicle, pin: "1234")
+  let result = porscheConnect.unlock(vin: vehicle.vin, pin: "1234")
   if let remoteCommandAccepted = result.remoteCommandAccepted {
     // Do something with the remote command
   }
@@ -326,7 +326,7 @@ Passing in a capabilites paramater is not required to determine the status of a 
 
 ```swift
 try {
-  let result = porscheConnect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommandAccepted)
+  let result = porscheConnect.checkStatus(vin: vehicle.vin, remoteCommand: remoteCommandAccepted)
   if let remoteCommandStatus = result.remoteCommand {
     // Do something with the remote command status
   }

--- a/Sources/CommandLineTool/Command+Flash.swift
+++ b/Sources/CommandLineTool/Command+Flash.swift
@@ -21,17 +21,16 @@ extension Porsche {
         password: options.password,
         environment: options.resolvedEnvironment
       )
-      let vehicle = Vehicle(vin: vin)
-      await callFlash(porscheConnect: porscheConnect, vehicle: vehicle)
+      await callFlash(porscheConnect: porscheConnect, vin: vin)
       dispatchMain()
     }
 
     // MARK: - Private functions
 
-    private func callFlash(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
+    private func callFlash(porscheConnect: PorscheConnect, vin: String) async {
 
       do {
-        let result = try await porscheConnect.flash(vehicle: vehicle)
+        let result = try await porscheConnect.flash(vin: vin)
         if let remoteCommandAccepted = result.remoteCommandAccepted {
           printRemoteCommandAccepted(remoteCommandAccepted)
         }

--- a/Sources/CommandLineTool/Command+HonkAndFlash.swift
+++ b/Sources/CommandLineTool/Command+HonkAndFlash.swift
@@ -20,17 +20,16 @@ extension Porsche {
         password: options.password,
         environment: options.resolvedEnvironment
       )
-      let vehicle = Vehicle(vin: vin)
-      await callHonkAndFlash(porscheConnect: porscheConnect, vehicle: vehicle)
+      await callHonkAndFlash(porscheConnect: porscheConnect, vin: vin)
       dispatchMain()
     }
 
     // MARK: - Private functions
 
-    private func callHonkAndFlash(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
+    private func callHonkAndFlash(porscheConnect: PorscheConnect, vin: String) async {
 
       do {
-        let result = try await porscheConnect.flash(vehicle: vehicle, andHonk: true)
+        let result = try await porscheConnect.flash(vin: vin, andHonk: true)
         if let remoteCommandAccepted = result.remoteCommandAccepted {
           printRemoteCommandAccepted(remoteCommandAccepted)
         }

--- a/Sources/CommandLineTool/Command+Lock.swift
+++ b/Sources/CommandLineTool/Command+Lock.swift
@@ -21,17 +21,16 @@ extension Porsche {
         password: options.password,
         environment: options.resolvedEnvironment
       )
-      let vehicle = Vehicle(vin: vin)
-      await callLock(porscheConnect: porscheConnect, vehicle: vehicle)
+      await callLock(porscheConnect: porscheConnect, vin: vin)
       dispatchMain()
     }
 
     // MARK: - Private functions
 
-    private func callLock(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
+    private func callLock(porscheConnect: PorscheConnect, vin: String) async {
 
       do {
-        let result = try await porscheConnect.lock(vehicle: vehicle)
+        let result = try await porscheConnect.lock(vin: vin)
         if let remoteCommandAccepted = result.remoteCommandAccepted {
           printRemoteCommandAccepted(remoteCommandAccepted)
         }

--- a/Sources/CommandLineTool/Command+ShowCapabilities.swift
+++ b/Sources/CommandLineTool/Command+ShowCapabilities.swift
@@ -21,17 +21,16 @@ extension Porsche {
         password: options.password,
         environment: options.resolvedEnvironment
       )
-      let vehicle = Vehicle(vin: vin)
-      await callCapabilitiesService(porscheConnect: porscheConnect, vehicle: vehicle)
+      await callCapabilitiesService(porscheConnect: porscheConnect, vin: vin)
       dispatchMain()
     }
 
     // MARK: - Private functions
 
-    private func callCapabilitiesService(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
+    private func callCapabilitiesService(porscheConnect: PorscheConnect, vin: String) async {
 
       do {
-        let result = try await porscheConnect.capabilities(vehicle: vehicle)
+        let result = try await porscheConnect.capabilities(vin: vin)
         if let capabilities = result.capabilities {
           printCapabilities(capabilities)
         }

--- a/Sources/CommandLineTool/Command+ShowEmobility.swift
+++ b/Sources/CommandLineTool/Command+ShowEmobility.swift
@@ -21,31 +21,29 @@ extension Porsche {
         password: options.password,
         environment: options.resolvedEnvironment
       )
-      let vehicle = Vehicle(vin: vin)
-      await callCapabilitiesService(porscheConnect: porscheConnect, vehicle: vehicle)
+      await callCapabilitiesService(porscheConnect: porscheConnect, vin: vin)
       dispatchMain()
     }
 
     // MARK: - Private functions
 
-    private func callCapabilitiesService(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
+    private func callCapabilitiesService(porscheConnect: PorscheConnect, vin: String) async {
       do {
-        let result = try await porscheConnect.capabilities(vehicle: vehicle)
+        let result = try await porscheConnect.capabilities(vin: vin)
         await callEmobilityService(
-          porscheConnect: porscheConnect, vehicle: vehicle, capabilities: result.capabilities)
+          porscheConnect: porscheConnect, vin: vin, capabilities: result.capabilities)
       } catch {
         Porsche.ShowEmobility.exit(withError: error)
       }
     }
 
     private func callEmobilityService(
-      porscheConnect: PorscheConnect, vehicle: Vehicle, capabilities: Capabilities?
+      porscheConnect: PorscheConnect, vin: String, capabilities: Capabilities?
     ) async {
       guard let capabilities = capabilities else { return }
 
       do {
-        let result = try await porscheConnect.emobility(
-          vehicle: vehicle, capabilities: capabilities)
+        let result = try await porscheConnect.emobility(vin: vin, capabilities: capabilities)
         if let emobility = result.emobility {
           printEmobility(emobility)
           Porsche.ShowEmobility.exit()

--- a/Sources/CommandLineTool/Command+ShowPosition.swift
+++ b/Sources/CommandLineTool/Command+ShowPosition.swift
@@ -21,16 +21,15 @@ extension Porsche {
         password: options.password,
         environment: options.resolvedEnvironment
       )
-      let vehicle = Vehicle(vin: vin)
-      await callPositionService(porscheConnect: porscheConnect, vehicle: vehicle)
+      await callPositionService(porscheConnect: porscheConnect, vin: vin)
       dispatchMain()
     }
 
     // MARK: - Private functions
 
-    private func callPositionService(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
+    private func callPositionService(porscheConnect: PorscheConnect, vin: String) async {
       do {
-        let result = try await porscheConnect.position(vehicle: vehicle)
+        let result = try await porscheConnect.position(vin: vin)
         if let position = result.position {
           printPosition(position)
         }

--- a/Sources/CommandLineTool/Command+ShowStatus.swift
+++ b/Sources/CommandLineTool/Command+ShowStatus.swift
@@ -20,17 +20,16 @@ extension Porsche {
         password: options.password,
         environment: options.resolvedEnvironment
       )
-      let vehicle = Vehicle(vin: vin)
-      await callStatusService(porscheConnect: porscheConnect, vehicle: vehicle)
+      await callStatusService(porscheConnect: porscheConnect, vin: vin)
       dispatchMain()
     }
 
     // MARK: - Private functions
 
-    private func callStatusService(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
+    private func callStatusService(porscheConnect: PorscheConnect, vin: String) async {
 
       do {
-        let result = try await porscheConnect.status(vehicle: vehicle)
+        let result = try await porscheConnect.status(vin: vin)
         if let status = result.status {
           printStatus(status)
         }

--- a/Sources/CommandLineTool/Command+ShowSummary.swift
+++ b/Sources/CommandLineTool/Command+ShowSummary.swift
@@ -20,17 +20,16 @@ extension Porsche {
         password: options.password,
         environment: options.resolvedEnvironment
       )
-      let vehicle = Vehicle(vin: vin)
-      await callSummaryService(porscheConnect: porscheConnect, vehicle: vehicle)
+      await callSummaryService(porscheConnect: porscheConnect, vin: vin)
       dispatchMain()
     }
 
     // MARK: - Private functions
 
-    private func callSummaryService(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
+    private func callSummaryService(porscheConnect: PorscheConnect, vin: String) async {
 
       do {
-        let result = try await porscheConnect.summary(vehicle: vehicle)
+        let result = try await porscheConnect.summary(vin: vin)
         if let summary = result.summary {
           printSummary(summary)
         }

--- a/Sources/CommandLineTool/Command+ToggleDirectCharging.swift
+++ b/Sources/CommandLineTool/Command+ToggleDirectCharging.swift
@@ -24,18 +24,17 @@ extension Porsche {
         password: options.password,
         environment: options.resolvedEnvironment
       )
-      let vehicle = Vehicle(vin: vin)
-      await callCapabilitiesService(porscheConnect: porscheConnect, vehicle: vehicle)
+      await callCapabilitiesService(porscheConnect: porscheConnect, vin: vin)
       dispatchMain()
     }
 
     // MARK: - Private functions
 
-    private func callCapabilitiesService(porscheConnect: PorscheConnect, vehicle: Vehicle) async {
+    private func callCapabilitiesService(porscheConnect: PorscheConnect, vin: String) async {
       do {
-        let result = try await porscheConnect.capabilities(vehicle: vehicle)
+        let result = try await porscheConnect.capabilities(vin: vin)
         await callToggleDirectChargeService(
-          porscheConnect: porscheConnect, vehicle: vehicle, capabilities: result.capabilities,
+          porscheConnect: porscheConnect, vin: vin, capabilities: result.capabilities,
           enable: toggleDirectChargingOn)
       } catch {
         Porsche.ToggleDirectCharging.exit(withError: error)
@@ -43,13 +42,13 @@ extension Porsche {
     }
 
     private func callToggleDirectChargeService(
-      porscheConnect: PorscheConnect, vehicle: Vehicle, capabilities: Capabilities?, enable: Bool
+      porscheConnect: PorscheConnect, vin: String, capabilities: Capabilities?, enable: Bool
     ) async {
       guard let capabilities = capabilities else { return }
 
       do {
         let result = try await porscheConnect.toggleDirectCharging(
-          vehicle: vehicle, capabilities: capabilities, enable: enable)
+          vin: vin, capabilities: capabilities, enable: enable)
         if let remoteCommandAccepted = result.remoteCommandAccepted {
           printRemoteCommandAccepted(remoteCommandAccepted)
           Porsche.ToggleDirectCharging.exit()

--- a/Sources/CommandLineTool/Command+ToggleDirectCharging.swift
+++ b/Sources/CommandLineTool/Command+ToggleDirectCharging.swift
@@ -12,7 +12,7 @@ extension Porsche {
 
     @Argument(help: ArgumentHelp(NSLocalizedString("Your vehicle VIN.", comment: "")))
     var vin: String
-    
+
     @Argument(help: ArgumentHelp(NSLocalizedString("Toggle Direct Charging on.", comment: "")))
     var toggleDirectChargingOn: Bool
 

--- a/Sources/CommandLineTool/Command+ToggleDirectClimatisation.swift
+++ b/Sources/CommandLineTool/Command+ToggleDirectClimatisation.swift
@@ -12,7 +12,7 @@ extension Porsche {
 
     @Argument(help: ArgumentHelp(NSLocalizedString("Your vehicle VIN.", comment: "")))
     var vin: String
-    
+
     @Argument(help: ArgumentHelp(NSLocalizedString("Toggle Direct Climatisation on.", comment: "")))
     var toggleDirectClimatisationOn: Bool
 
@@ -24,7 +24,8 @@ extension Porsche {
         password: options.password,
         environment: options.resolvedEnvironment
       )
-      await callToggleDirectClimatisationService(porscheConnect: porscheConnect, vin: vin, enable: toggleDirectClimatisationOn)
+      await callToggleDirectClimatisationService(
+        porscheConnect: porscheConnect, vin: vin, enable: toggleDirectClimatisationOn)
       dispatchMain()
     }
 

--- a/Sources/CommandLineTool/Command+ToggleDirectClimatisation.swift
+++ b/Sources/CommandLineTool/Command+ToggleDirectClimatisation.swift
@@ -24,19 +24,17 @@ extension Porsche {
         password: options.password,
         environment: options.resolvedEnvironment
       )
-      let vehicle = Vehicle(vin: vin)
-      await callToggleDirectClimatisationService(porscheConnect: porscheConnect, vehicle: vehicle, enable: toggleDirectClimatisationOn)
+      await callToggleDirectClimatisationService(porscheConnect: porscheConnect, vin: vin, enable: toggleDirectClimatisationOn)
       dispatchMain()
     }
 
     // MARK: - Private functions
 
     private func callToggleDirectClimatisationService(
-      porscheConnect: PorscheConnect, vehicle: Vehicle, enable: Bool
+      porscheConnect: PorscheConnect, vin: String, enable: Bool
     ) async {
       do {
-        let result = try await porscheConnect.toggleDirectClimatisation(
-          vehicle: vehicle, enable: enable)
+        let result = try await porscheConnect.toggleDirectClimatisation(vin: vin, enable: enable)
         if let remoteCommandAccepted = result.remoteCommandAccepted {
           printRemoteCommandAccepted(remoteCommandAccepted)
           Porsche.ToggleDirectCharging.exit()

--- a/Sources/CommandLineTool/Command+Unlock.swift
+++ b/Sources/CommandLineTool/Command+Unlock.swift
@@ -24,17 +24,16 @@ extension Porsche {
         password: options.password,
         environment: options.resolvedEnvironment
       )
-      let vehicle = Vehicle(vin: vin)
-      await callUnlock(porscheConnect: porscheConnect, vehicle: vehicle, pin: pin)
+      await callUnlock(porscheConnect: porscheConnect, vin: vin, pin: pin)
       dispatchMain()
     }
 
     // MARK: - Private functions
 
-    private func callUnlock(porscheConnect: PorscheConnect, vehicle: Vehicle, pin: String) async {
+    private func callUnlock(porscheConnect: PorscheConnect, vin: String, pin: String) async {
 
       do {
-        let result = try await porscheConnect.unlock(vehicle: vehicle, pin: pin)
+        let result = try await porscheConnect.unlock(vin: vin, pin: pin)
         if let remoteCommandAccepted = result.remoteCommandAccepted {
           printRemoteCommandAccepted(remoteCommandAccepted)
         }

--- a/Sources/CommandLineTool/Command+Unlock.swift
+++ b/Sources/CommandLineTool/Command+Unlock.swift
@@ -44,7 +44,7 @@ extension Porsche {
     }
 
     private func printRemoteCommandAccepted(_ remoteCommandAccepted: RemoteCommandAccepted) {
-      if (remoteCommandAccepted.pcckErrorKey != nil) {
+      if remoteCommandAccepted.pcckErrorKey != nil {
         printError(remoteCommandAccepted)
       } else {
         print(
@@ -72,4 +72,3 @@ extension Porsche {
     }
   }
 }
-

--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -28,109 +28,105 @@ struct NetworkRoutes {
 
   // MARK: - Functions
 
-  func vehicleSummaryURL(vehicle: Vehicle) -> URL {
+  func vehicleSummaryURL(vin: String) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/service-vehicle/vehicle-summary/\(vehicle.vin)")!
+      string: "\(host("https://api.porsche.com"))/service-vehicle/vehicle-summary/\(vin)")!
   }
 
-  func vehiclePositionURL(vehicle: Vehicle) -> URL {
+  func vehiclePositionURL(vin: String) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/service-vehicle/car-finder/\(vehicle.vin)/position")!
+        "\(host("https://api.porsche.com"))/service-vehicle/car-finder/\(vin)/position")!
   }
 
-  func vehicleCapabilitiesURL(vehicle: Vehicle) -> URL {
+  func vehicleCapabilitiesURL(vin: String) -> URL {
     return URL(
-      string: "\(host("https://api.porsche.com"))/service-vehicle/vcs/capabilities/\(vehicle.vin)")!
+      string: "\(host("https://api.porsche.com"))/service-vehicle/vcs/capabilities/\(vin)")!
   }
 
-  func vehicleStatusURL(vehicle: Vehicle) -> URL {
+  func vehicleStatusURL(vin: String) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/vehicle-data/\(environment.regionCode)/status/\(vehicle.vin)"
+        "\(host("https://api.porsche.com"))/vehicle-data/\(environment.regionCode)/status/\(vin)"
     )!
   }
 
-  func vehicleEmobilityURL(vehicle: Vehicle, capabilities: Capabilities? = nil) -> URL {
+  func vehicleEmobilityURL(vin: String, capabilities: Capabilities? = nil) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vehicle.vin)?timezone=Europe/Dublin"
+        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vin)?timezone=Europe/Dublin"
     )!
   }
 
-  func vehicleFlashURL(vehicle: Vehicle) -> URL {
+  func vehicleFlashURL(vin: String) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/service-vehicle/honk-and-flash/\(vehicle.vin)/flash")!
+        "\(host("https://api.porsche.com"))/service-vehicle/honk-and-flash/\(vin)/flash")!
   }
 
-  func vehicleHonkAndFlashURL(vehicle: Vehicle) -> URL {
+  func vehicleHonkAndFlashURL(vin: String) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/service-vehicle/honk-and-flash/\(vehicle.vin)/honk-and-flash"
+        "\(host("https://api.porsche.com"))/service-vehicle/honk-and-flash/\(vin)/honk-and-flash"
     )!
   }
 
   func vehicleHonkAndFlashRemoteCommandStatusURL(
-    vehicle: Vehicle, remoteCommand: RemoteCommandAccepted
+    vin: String, remoteCommand: RemoteCommandAccepted
   ) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/service-vehicle/honk-and-flash/\(vehicle.vin)/\(remoteCommand.identifier!)/status"
+        "\(host("https://api.porsche.com"))/service-vehicle/honk-and-flash/\(vin)/\(remoteCommand.identifier!)/status"
     )!
   }
 
   func vehicleToggleDirectChargingURL(
-    vehicle: Vehicle, capabilities: Capabilities? = nil, enable: Bool
+    vin: String, capabilities: Capabilities? = nil, enable: Bool
   ) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vehicle.vin)/toggle-direct-charging/\(enable)"
+        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vin)/toggle-direct-charging/\(enable)"
     )!
   }
 
   func vehicleToggleDirectChargingRemoteCommandStatusURL(
-    vehicle: Vehicle, capabilities: Capabilities? = nil, remoteCommand: RemoteCommandAccepted
+    vin: String, capabilities: Capabilities? = nil, remoteCommand: RemoteCommandAccepted
   ) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vehicle.vin)/toggle-direct-charging/status/\(remoteCommand.identifier!)"
+        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(capabilities?.carModel ?? kDefaultCarModel)/\(vin)/toggle-direct-charging/status/\(remoteCommand.identifier!)"
     )!
   }
 
-  func vehicleToggleDirectClimatisationURL(
-    vehicle: Vehicle, enable: Bool
-  ) -> URL {
+  func vehicleToggleDirectClimatisationURL(vin: String, enable: Bool) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(vehicle.vin)/toggle-direct-climatisation/\(enable ? "true" : "false")"
+        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(vin)/toggle-direct-climatisation/\(enable ? "true" : "false")"
     )!
   }
   
   func vehicleToggleDirectClimatisationRemoteCommandStatusURL(
-    vehicle: Vehicle, remoteCommand: RemoteCommandAccepted
+    vin: String, remoteCommand: RemoteCommandAccepted
   ) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(vehicle.vin)/toggle-direct-climatisation/status/\(remoteCommand.identifier!)"
+        "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(vin)/toggle-direct-climatisation/status/\(remoteCommand.identifier!)"
     )!
   }
   
-  func vehicleLockUnlockURL(
-    vehicle: Vehicle, lock: Bool
-  ) -> URL {
+  func vehicleLockUnlockURL(vin: String, lock: Bool) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vehicle.vin)/\(lock ? "quick-lock" : "security-pin/unlock")"
+        "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vin)/\(lock ? "quick-lock" : "security-pin/unlock")"
     )!
   }
 
   func vehicleLockUnlockRemoteCommandStatusURL(
-    vehicle: Vehicle, remoteCommand: RemoteCommandAccepted
+    vin: String, remoteCommand: RemoteCommandAccepted
   ) -> URL {
     return URL(
       string:
-        "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vehicle.vin)/\(remoteCommand.identifier!)/status"
+        "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vin)/\(remoteCommand.identifier!)/status"
     )!
   }
 

--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -104,7 +104,7 @@ struct NetworkRoutes {
         "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(vin)/toggle-direct-climatisation/\(enable ? "true" : "false")"
     )!
   }
-  
+
   func vehicleToggleDirectClimatisationRemoteCommandStatusURL(
     vin: String, remoteCommand: RemoteCommandAccepted
   ) -> URL {
@@ -113,7 +113,7 @@ struct NetworkRoutes {
         "\(host("https://api.porsche.com"))/e-mobility/\(environment.regionCode)/\(vin)/toggle-direct-climatisation/status/\(remoteCommand.identifier!)"
     )!
   }
-  
+
   func vehicleLockUnlockURL(vin: String, lock: Bool) -> URL {
     return URL(
       string:

--- a/Sources/PorscheConnect/PorscheConnect+CarControl.swift
+++ b/Sources/PorscheConnect/PorscheConnect+CarControl.swift
@@ -90,7 +90,7 @@ extension PorscheConnect {
     result.data?.remoteCommand = .toggleDirectCharge
     return (remoteCommandAccepted: result.data, response: result.response)
   }
-  
+
   public func toggleDirectClimatisation(
     vin: String, enable: Bool = true
   ) async throws -> (

--- a/Sources/PorscheConnect/PorscheConnect+CarControl.swift
+++ b/Sources/PorscheConnect/PorscheConnect+CarControl.swift
@@ -2,71 +2,71 @@ import Foundation
 
 extension PorscheConnect {
 
-  public func summary(vehicle: Vehicle) async throws -> (
+  public func summary(vin: String) async throws -> (
     summary: Summary?, response: HTTPURLResponse
   ) {
     let headers = try await performAuthFor(application: .carControl)
 
     let result = try await networkClient.get(
-      Summary.self, url: networkRoutes.vehicleSummaryURL(vehicle: vehicle), headers: headers,
+      Summary.self, url: networkRoutes.vehicleSummaryURL(vin: vin), headers: headers,
       jsonKeyDecodingStrategy: .useDefaultKeys)
     return (summary: result.data, response: result.response)
   }
 
-  public func position(vehicle: Vehicle) async throws -> (
+  public func position(vin: String) async throws -> (
     position: Position?, response: HTTPURLResponse
   ) {
     let headers = try await performAuthFor(application: .carControl)
 
     let result = try await networkClient.get(
-      Position.self, url: networkRoutes.vehiclePositionURL(vehicle: vehicle), headers: headers,
+      Position.self, url: networkRoutes.vehiclePositionURL(vin: vin), headers: headers,
       jsonKeyDecodingStrategy: .useDefaultKeys)
     return (position: result.data, response: result.response)
   }
 
-  public func capabilities(vehicle: Vehicle) async throws -> (
+  public func capabilities(vin: String) async throws -> (
     capabilities: Capabilities?, response: HTTPURLResponse
   ) {
     let headers = try await performAuthFor(application: .carControl)
 
     let result = try await networkClient.get(
-      Capabilities.self, url: networkRoutes.vehicleCapabilitiesURL(vehicle: vehicle),
+      Capabilities.self, url: networkRoutes.vehicleCapabilitiesURL(vin: vin),
       headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys)
     return (capabilities: result.data, response: result.response)
   }
 
-  public func emobility(vehicle: Vehicle, capabilities: Capabilities) async throws -> (
+  public func emobility(vin: String, capabilities: Capabilities) async throws -> (
     emobility: Emobility?, response: HTTPURLResponse
   ) {
     let headers = try await performAuthFor(application: .carControl)
 
     let result = try await networkClient.get(
       Emobility.self,
-      url: networkRoutes.vehicleEmobilityURL(vehicle: vehicle, capabilities: capabilities),
+      url: networkRoutes.vehicleEmobilityURL(vin: vin, capabilities: capabilities),
       headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys)
     return (emobility: result.data, response: result.response)
   }
 
-  public func status(vehicle: Vehicle) async throws -> (
+  public func status(vin: String) async throws -> (
     status: Status?, response: HTTPURLResponse
   ) {
     let headers = try await performAuthFor(application: .api)
 
     let result = try await networkClient.get(
-      Status.self, url: networkRoutes.vehicleStatusURL(vehicle: vehicle), headers: headers,
+      Status.self, url: networkRoutes.vehicleStatusURL(vin: vin), headers: headers,
       jsonKeyDecodingStrategy: .useDefaultKeys)
     return (status: result.data, response: result.response)
   }
 
-  public func flash(vehicle: Vehicle, andHonk honk: Bool = false) async throws -> (
+  public func flash(vin: String, andHonk honk: Bool = false) async throws -> (
     remoteCommandAccepted: RemoteCommandAccepted?, response: HTTPURLResponse
   ) {
     let headers = try await performAuthFor(application: .carControl)
 
     let url =
       honk
-      ? networkRoutes.vehicleHonkAndFlashURL(vehicle: vehicle)
-      : networkRoutes.vehicleFlashURL(vehicle: vehicle)
+      ? networkRoutes.vehicleHonkAndFlashURL(vin: vin)
+      : networkRoutes.vehicleFlashURL(vin: vin)
 
     var result = try await networkClient.post(
       RemoteCommandAccepted.self, url: url, body: kBlankString, headers: headers,
@@ -76,13 +76,13 @@ extension PorscheConnect {
   }
 
   public func toggleDirectCharging(
-    vehicle: Vehicle, capabilities: Capabilities, enable: Bool = true
+    vin: String, capabilities: Capabilities, enable: Bool = true
   ) async throws -> (
     remoteCommandAccepted: RemoteCommandAccepted?, response: HTTPURLResponse
   ) {
     let headers = try await performAuthFor(application: .carControl)
     let url = networkRoutes.vehicleToggleDirectChargingURL(
-      vehicle: vehicle, capabilities: capabilities, enable: enable)
+      vin: vin, capabilities: capabilities, enable: enable)
 
     var result = try await networkClient.post(
       RemoteCommandAccepted.self, url: url, body: kBlankString, headers: headers,
@@ -92,13 +92,13 @@ extension PorscheConnect {
   }
   
   public func toggleDirectClimatisation(
-    vehicle: Vehicle, enable: Bool = true
+    vin: String, enable: Bool = true
   ) async throws -> (
     remoteCommandAccepted: RemoteCommandAccepted?, response: HTTPURLResponse
   ) {
     let headers = try await performAuthFor(application: .carControl)
     let url = networkRoutes.vehicleToggleDirectClimatisationURL(
-      vehicle: vehicle, enable: enable)
+      vin: vin, enable: enable)
 
     var result = try await networkClient.post(
       RemoteCommandAccepted.self, url: url, body: kBlankString, headers: headers,
@@ -107,11 +107,11 @@ extension PorscheConnect {
     return (remoteCommandAccepted: result.data, response: result.response)
   }
 
-  public func lock(vehicle: Vehicle) async throws -> (
+  public func lock(vin: String) async throws -> (
     remoteCommandAccepted: RemoteCommandAccepted?, response: HTTPURLResponse
   ) {
     let headers = try await performAuthFor(application: .carControl)
-    let url = networkRoutes.vehicleLockUnlockURL(vehicle: vehicle, lock: true)
+    let url = networkRoutes.vehicleLockUnlockURL(vin: vin, lock: true)
 
     var result = try await networkClient.post(
       RemoteCommandAccepted.self, url: url, body: kBlankString, headers: headers,
@@ -120,11 +120,11 @@ extension PorscheConnect {
     return (remoteCommandAccepted: result.data, response: result.response)
   }
 
-  public func unlock(vehicle: Vehicle, pin: String) async throws -> (
+  public func unlock(vin: String, pin: String) async throws -> (
     remoteCommandAccepted: RemoteCommandAccepted?, response: HTTPURLResponse
   ) {
     let headers = try await performAuthFor(application: .carControl)
-    let url = networkRoutes.vehicleLockUnlockURL(vehicle: vehicle, lock: false)
+    let url = networkRoutes.vehicleLockUnlockURL(vin: vin, lock: false)
 
     let pinSecurity = try await networkClient.get(
       PinSecurity.self, url: url, headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys

--- a/Sources/PorscheConnect/PorscheConnect+RemoteCommandStatus.swift
+++ b/Sources/PorscheConnect/PorscheConnect+RemoteCommandStatus.swift
@@ -20,15 +20,15 @@ extension PorscheConnect {
     switch remoteCommand.remoteCommand {
     case .honkAndFlash:
       return networkRoutes.vehicleHonkAndFlashRemoteCommandStatusURL(
-        vehicle: vehicle, remoteCommand: remoteCommand)
+        vin: vehicle.vin, remoteCommand: remoteCommand)
     case .toggleDirectCharge:
       return networkRoutes.vehicleToggleDirectChargingRemoteCommandStatusURL(
-        vehicle: vehicle, capabilities: capabilities, remoteCommand: remoteCommand)
+        vin: vehicle.vin, capabilities: capabilities, remoteCommand: remoteCommand)
     case .toggleDirectClimatisation:
       return networkRoutes.vehicleToggleDirectClimatisationRemoteCommandStatusURL(
-        vehicle: vehicle, remoteCommand: remoteCommand)
+        vin: vehicle.vin, remoteCommand: remoteCommand)
     case .lock, .unlock:
-      return networkRoutes.vehicleLockUnlockRemoteCommandStatusURL(vehicle: vehicle, remoteCommand: remoteCommand)
+      return networkRoutes.vehicleLockUnlockRemoteCommandStatusURL(vin: vehicle.vin, remoteCommand: remoteCommand)
     case .none:
       return URL(string: kBlankString)!
     }

--- a/Sources/PorscheConnect/PorscheConnect+RemoteCommandStatus.swift
+++ b/Sources/PorscheConnect/PorscheConnect+RemoteCommandStatus.swift
@@ -2,21 +2,27 @@ import Foundation
 
 extension PorscheConnect {
 
-  public func checkStatus(vehicle: Vehicle, capabilities: Capabilities? = nil,
-                          remoteCommand: RemoteCommandAccepted) async throws -> (
+  public func checkStatus(
+    vehicle: Vehicle, capabilities: Capabilities? = nil,
+    remoteCommand: RemoteCommandAccepted
+  ) async throws -> (
     status: RemoteCommandStatus?, response: HTTPURLResponse?
   ) {
     let headers = try await performAuthFor(application: .carControl)
 
     let result = try await networkClient.get(
-      RemoteCommandStatus.self, url: urlForCommand(vehicle: vehicle, capabilities: capabilities, remoteCommand: remoteCommand),
+      RemoteCommandStatus.self,
+      url: urlForCommand(
+        vehicle: vehicle, capabilities: capabilities, remoteCommand: remoteCommand),
       headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys)
     return (status: result.data, response: result.response)
   }
 
   // MARK: - Private
 
-  private func urlForCommand(vehicle: Vehicle, capabilities: Capabilities?, remoteCommand: RemoteCommandAccepted) -> URL {
+  private func urlForCommand(
+    vehicle: Vehicle, capabilities: Capabilities?, remoteCommand: RemoteCommandAccepted
+  ) -> URL {
     switch remoteCommand.remoteCommand {
     case .honkAndFlash:
       return networkRoutes.vehicleHonkAndFlashRemoteCommandStatusURL(
@@ -28,7 +34,8 @@ extension PorscheConnect {
       return networkRoutes.vehicleToggleDirectClimatisationRemoteCommandStatusURL(
         vin: vehicle.vin, remoteCommand: remoteCommand)
     case .lock, .unlock:
-      return networkRoutes.vehicleLockUnlockRemoteCommandStatusURL(vin: vehicle.vin, remoteCommand: remoteCommand)
+      return networkRoutes.vehicleLockUnlockRemoteCommandStatusURL(
+        vin: vehicle.vin, remoteCommand: remoteCommand)
     case .none:
       return URL(string: kBlankString)!
     }

--- a/Tests/PorscheConnectTests/Networking/NetworkRoutesTests.swift
+++ b/Tests/PorscheConnectTests/Networking/NetworkRoutesTests.swift
@@ -37,62 +37,62 @@ final class NetworkRoutesTests: XCTestCase {
     XCTAssertEqual(
       URL(string: "https://login.porsche.com/as/token.oauth2")!, networkRoute.apiTokenURL)
 
-    let vehicle = Vehicle(vin: "12345X")
+    let vin = "12345X"
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/service-vehicle/vehicle-summary/12345X"),
-      networkRoute.vehicleSummaryURL(vehicle: vehicle))
+      networkRoute.vehicleSummaryURL(vin: vin))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/service-vehicle/car-finder/12345X/position"),
-      networkRoute.vehiclePositionURL(vehicle: vehicle))
+      networkRoute.vehiclePositionURL(vin: vin))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/service-vehicle/vcs/capabilities/12345X"),
-      networkRoute.vehicleCapabilitiesURL(vehicle: vehicle))
+      networkRoute.vehicleCapabilitiesURL(vin: vin))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/e-mobility/de/de_DE/J1/12345X?timezone=Europe/Dublin"),
-      networkRoute.vehicleEmobilityURL(vehicle: vehicle, capabilities: capabilities!))
+      networkRoute.vehicleEmobilityURL(vin: vin, capabilities: capabilities!))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/service-vehicle/honk-and-flash/12345X/flash"),
-      networkRoute.vehicleFlashURL(vehicle: vehicle))
+      networkRoute.vehicleFlashURL(vin: vin))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/service-vehicle/honk-and-flash/12345X/honk-and-flash"),
-      networkRoute.vehicleHonkAndFlashURL(vehicle: vehicle))
+      networkRoute.vehicleHonkAndFlashURL(vin: vin))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/service-vehicle/honk-and-flash/12345X/123456/status"),
       networkRoute.vehicleHonkAndFlashRemoteCommandStatusURL(
-        vehicle: vehicle, remoteCommand: RemoteCommandAccepted(id: "123456", lastUpdated: Date())))
+        vin: vin, remoteCommand: RemoteCommandAccepted(id: "123456", lastUpdated: Date())))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/e-mobility/de/de_DE/J1/12345X/toggle-direct-charging/true"),
-      networkRoute.vehicleToggleDirectChargingURL(vehicle: vehicle, capabilities: capabilities!, enable: true))
+      networkRoute.vehicleToggleDirectChargingURL(vin: vin, capabilities: capabilities!, enable: true))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/e-mobility/de/de_DE/J1/12345X/toggle-direct-charging/false"),
-      networkRoute.vehicleToggleDirectChargingURL(vehicle: vehicle, capabilities: capabilities!, enable: false))
+      networkRoute.vehicleToggleDirectChargingURL(vin: vin, capabilities: capabilities!, enable: false))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/e-mobility/de/de_DE/J1/12345X/toggle-direct-charging/status/123456"),
       networkRoute.vehicleToggleDirectChargingRemoteCommandStatusURL(
-        vehicle: vehicle,
+        vin: vin,
         capabilities: capabilities!,
         remoteCommand: RemoteCommandAccepted(requestId: "123456")))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/e-mobility/de/de_DE/12345X/toggle-direct-climatisation/true"),
-      networkRoute.vehicleToggleDirectClimatisationURL(vehicle: vehicle, enable: true))
+      networkRoute.vehicleToggleDirectClimatisationURL(vin: vin, enable: true))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/e-mobility/de/de_DE/12345X/toggle-direct-climatisation/false"),
-      networkRoute.vehicleToggleDirectClimatisationURL(vehicle: vehicle, enable: false))
+      networkRoute.vehicleToggleDirectClimatisationURL(vin: vin, enable: false))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/e-mobility/de/de_DE/12345X/toggle-direct-climatisation/status/123456"),
       networkRoute.vehicleToggleDirectClimatisationRemoteCommandStatusURL(
-        vehicle: vehicle,
+        vin: vin,
         remoteCommand: RemoteCommandAccepted(requestId: "123456")))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/service-vehicle/remote-lock-unlock/12345X/quick-lock"),
-      networkRoute.vehicleLockUnlockURL(vehicle: vehicle, lock: true))
+      networkRoute.vehicleLockUnlockURL(vin: vin, lock: true))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/service-vehicle/remote-lock-unlock/12345X/security-pin/unlock"),
-      networkRoute.vehicleLockUnlockURL(vehicle: vehicle, lock: false))
+      networkRoute.vehicleLockUnlockURL(vin: vin, lock: false))
     XCTAssertEqual(
       URL(string: "https://api.porsche.com/service-vehicle/remote-lock-unlock/12345X/123456/status"),
       networkRoute.vehicleLockUnlockRemoteCommandStatusURL(
-        vehicle: vehicle, remoteCommand: RemoteCommandAccepted(requestId: "123456")))
+        vin: vin, remoteCommand: RemoteCommandAccepted(requestId: "123456")))
   }
 
   func testNetworkRoutesTest() {
@@ -106,84 +106,84 @@ final class NetworkRoutesTests: XCTestCase {
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/as/token.oauth2")!, networkRoute.apiTokenURL)
 
-    let vehicle = Vehicle(vin: "12345X")
+    let vin = "12345X"
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/vehicle-summary/12345X"),
-      networkRoute.vehicleSummaryURL(vehicle: vehicle))
+      networkRoute.vehicleSummaryURL(vin: vin))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/car-finder/12345X/position"),
-      networkRoute.vehiclePositionURL(vehicle: vehicle))
+      networkRoute.vehiclePositionURL(vin: vin))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/vcs/capabilities/12345X"),
-      networkRoute.vehicleCapabilitiesURL(vehicle: vehicle))
+      networkRoute.vehicleCapabilitiesURL(vin: vin))
     XCTAssertEqual(
       URL(
         string:
           "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X?timezone=Europe/Dublin"
-      ), networkRoute.vehicleEmobilityURL(vehicle: vehicle, capabilities: capabilities!))
+      ), networkRoute.vehicleEmobilityURL(vin: vin, capabilities: capabilities!))
     XCTAssertEqual(
       URL(
         string:
           "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X?timezone=Europe/Dublin"
-      ), networkRoute.vehicleEmobilityURL(vehicle: vehicle))
+      ), networkRoute.vehicleEmobilityURL(vin: vin))
     XCTAssertEqual(
       URL(
         string: "http://localhost:\(kTestServerPort)/service-vehicle/honk-and-flash/12345X/flash"),
-      networkRoute.vehicleFlashURL(vehicle: vehicle))
+      networkRoute.vehicleFlashURL(vin: vin))
     XCTAssertEqual(
       URL(
         string:
           "http://localhost:\(kTestServerPort)/service-vehicle/honk-and-flash/12345X/honk-and-flash"
-      ), networkRoute.vehicleHonkAndFlashURL(vehicle: vehicle))
+      ), networkRoute.vehicleHonkAndFlashURL(vin: vin))
     XCTAssertEqual(
       URL(
         string:
           "http://localhost:\(kTestServerPort)/service-vehicle/honk-and-flash/12345X/123456/status"),
       networkRoute.vehicleHonkAndFlashRemoteCommandStatusURL(
-        vehicle: vehicle, remoteCommand: RemoteCommandAccepted(id: "123456", lastUpdated: Date())))
+        vin: vin, remoteCommand: RemoteCommandAccepted(id: "123456", lastUpdated: Date())))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/true"),
-      networkRoute.vehicleToggleDirectChargingURL(vehicle: vehicle, capabilities: capabilities!, enable: true))
+      networkRoute.vehicleToggleDirectChargingURL(vin: vin, capabilities: capabilities!, enable: true))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/true"),
-      networkRoute.vehicleToggleDirectChargingURL(vehicle: vehicle, enable: true))
+      networkRoute.vehicleToggleDirectChargingURL(vin: vin, enable: true))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/false"),
-      networkRoute.vehicleToggleDirectChargingURL(vehicle: vehicle, capabilities: capabilities!, enable: false))
+      networkRoute.vehicleToggleDirectChargingURL(vin: vin, capabilities: capabilities!, enable: false))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/false"),
-      networkRoute.vehicleToggleDirectChargingURL(vehicle: vehicle, enable: false))
+      networkRoute.vehicleToggleDirectChargingURL(vin: vin, enable: false))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/status/123456"),
       networkRoute.vehicleToggleDirectChargingRemoteCommandStatusURL(
-        vehicle: vehicle,
+        vin: vin,
         capabilities: capabilities!,
         remoteCommand: RemoteCommandAccepted(requestId: "123456")))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/status/123456"),
       networkRoute.vehicleToggleDirectChargingRemoteCommandStatusURL(
-        vehicle: vehicle,
+        vin: vin,
         remoteCommand: RemoteCommandAccepted(requestId: "123456")))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/12345X/toggle-direct-climatisation/true"),
-      networkRoute.vehicleToggleDirectClimatisationURL(vehicle: vehicle, enable: true))
+      networkRoute.vehicleToggleDirectClimatisationURL(vin: vin, enable: true))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/12345X/toggle-direct-climatisation/false"),
-      networkRoute.vehicleToggleDirectClimatisationURL(vehicle: vehicle, enable: false))
+      networkRoute.vehicleToggleDirectClimatisationURL(vin: vin, enable: false))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/12345X/toggle-direct-climatisation/status/123456"),
       networkRoute.vehicleToggleDirectClimatisationRemoteCommandStatusURL(
-        vehicle: vehicle,
+        vin: vin,
         remoteCommand: RemoteCommandAccepted(requestId: "123456")))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/remote-lock-unlock/12345X/quick-lock"),
-      networkRoute.vehicleLockUnlockURL(vehicle: vehicle, lock: true))
+      networkRoute.vehicleLockUnlockURL(vin: vin, lock: true))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/remote-lock-unlock/12345X/security-pin/unlock"),
-      networkRoute.vehicleLockUnlockURL(vehicle: vehicle, lock: false))
+      networkRoute.vehicleLockUnlockURL(vin: vin, lock: false))
     XCTAssertEqual(
       URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/remote-lock-unlock/12345X/123456/status"),
       networkRoute.vehicleLockUnlockRemoteCommandStatusURL(
-        vehicle: vehicle, remoteCommand: RemoteCommandAccepted(requestId: "123456")))
+        vin: vin, remoteCommand: RemoteCommandAccepted(requestId: "123456")))
   }
 }

--- a/Tests/PorscheConnectTests/Networking/NetworkRoutesTests.swift
+++ b/Tests/PorscheConnectTests/Networking/NetworkRoutesTests.swift
@@ -61,25 +61,40 @@ final class NetworkRoutesTests: XCTestCase {
       networkRoute.vehicleHonkAndFlashRemoteCommandStatusURL(
         vin: vin, remoteCommand: RemoteCommandAccepted(id: "123456", lastUpdated: Date())))
     XCTAssertEqual(
-      URL(string: "https://api.porsche.com/e-mobility/de/de_DE/J1/12345X/toggle-direct-charging/true"),
-      networkRoute.vehicleToggleDirectChargingURL(vin: vin, capabilities: capabilities!, enable: true))
+      URL(
+        string: "https://api.porsche.com/e-mobility/de/de_DE/J1/12345X/toggle-direct-charging/true"),
+      networkRoute.vehicleToggleDirectChargingURL(
+        vin: vin, capabilities: capabilities!, enable: true))
     XCTAssertEqual(
-      URL(string: "https://api.porsche.com/e-mobility/de/de_DE/J1/12345X/toggle-direct-charging/false"),
-      networkRoute.vehicleToggleDirectChargingURL(vin: vin, capabilities: capabilities!, enable: false))
+      URL(
+        string: "https://api.porsche.com/e-mobility/de/de_DE/J1/12345X/toggle-direct-charging/false"
+      ),
+      networkRoute.vehicleToggleDirectChargingURL(
+        vin: vin, capabilities: capabilities!, enable: false))
     XCTAssertEqual(
-      URL(string: "https://api.porsche.com/e-mobility/de/de_DE/J1/12345X/toggle-direct-charging/status/123456"),
+      URL(
+        string:
+          "https://api.porsche.com/e-mobility/de/de_DE/J1/12345X/toggle-direct-charging/status/123456"
+      ),
       networkRoute.vehicleToggleDirectChargingRemoteCommandStatusURL(
         vin: vin,
         capabilities: capabilities!,
         remoteCommand: RemoteCommandAccepted(requestId: "123456")))
     XCTAssertEqual(
-      URL(string: "https://api.porsche.com/e-mobility/de/de_DE/12345X/toggle-direct-climatisation/true"),
+      URL(
+        string:
+          "https://api.porsche.com/e-mobility/de/de_DE/12345X/toggle-direct-climatisation/true"),
       networkRoute.vehicleToggleDirectClimatisationURL(vin: vin, enable: true))
     XCTAssertEqual(
-      URL(string: "https://api.porsche.com/e-mobility/de/de_DE/12345X/toggle-direct-climatisation/false"),
+      URL(
+        string:
+          "https://api.porsche.com/e-mobility/de/de_DE/12345X/toggle-direct-climatisation/false"),
       networkRoute.vehicleToggleDirectClimatisationURL(vin: vin, enable: false))
     XCTAssertEqual(
-      URL(string: "https://api.porsche.com/e-mobility/de/de_DE/12345X/toggle-direct-climatisation/status/123456"),
+      URL(
+        string:
+          "https://api.porsche.com/e-mobility/de/de_DE/12345X/toggle-direct-climatisation/status/123456"
+      ),
       networkRoute.vehicleToggleDirectClimatisationRemoteCommandStatusURL(
         vin: vin,
         remoteCommand: RemoteCommandAccepted(requestId: "123456")))
@@ -87,10 +102,13 @@ final class NetworkRoutesTests: XCTestCase {
       URL(string: "https://api.porsche.com/service-vehicle/remote-lock-unlock/12345X/quick-lock"),
       networkRoute.vehicleLockUnlockURL(vin: vin, lock: true))
     XCTAssertEqual(
-      URL(string: "https://api.porsche.com/service-vehicle/remote-lock-unlock/12345X/security-pin/unlock"),
+      URL(
+        string:
+          "https://api.porsche.com/service-vehicle/remote-lock-unlock/12345X/security-pin/unlock"),
       networkRoute.vehicleLockUnlockURL(vin: vin, lock: false))
     XCTAssertEqual(
-      URL(string: "https://api.porsche.com/service-vehicle/remote-lock-unlock/12345X/123456/status"),
+      URL(
+        string: "https://api.porsche.com/service-vehicle/remote-lock-unlock/12345X/123456/status"),
       networkRoute.vehicleLockUnlockRemoteCommandStatusURL(
         vin: vin, remoteCommand: RemoteCommandAccepted(requestId: "123456")))
   }
@@ -142,47 +160,85 @@ final class NetworkRoutesTests: XCTestCase {
       networkRoute.vehicleHonkAndFlashRemoteCommandStatusURL(
         vin: vin, remoteCommand: RemoteCommandAccepted(id: "123456", lastUpdated: Date())))
     XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/true"),
-      networkRoute.vehicleToggleDirectChargingURL(vin: vin, capabilities: capabilities!, enable: true))
+      URL(
+        string:
+          "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/true"
+      ),
+      networkRoute.vehicleToggleDirectChargingURL(
+        vin: vin, capabilities: capabilities!, enable: true))
     XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/true"),
+      URL(
+        string:
+          "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/true"
+      ),
       networkRoute.vehicleToggleDirectChargingURL(vin: vin, enable: true))
     XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/false"),
-      networkRoute.vehicleToggleDirectChargingURL(vin: vin, capabilities: capabilities!, enable: false))
+      URL(
+        string:
+          "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/false"
+      ),
+      networkRoute.vehicleToggleDirectChargingURL(
+        vin: vin, capabilities: capabilities!, enable: false))
     XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/false"),
+      URL(
+        string:
+          "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/false"
+      ),
       networkRoute.vehicleToggleDirectChargingURL(vin: vin, enable: false))
     XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/status/123456"),
+      URL(
+        string:
+          "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/status/123456"
+      ),
       networkRoute.vehicleToggleDirectChargingRemoteCommandStatusURL(
         vin: vin,
         capabilities: capabilities!,
         remoteCommand: RemoteCommandAccepted(requestId: "123456")))
     XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/status/123456"),
+      URL(
+        string:
+          "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/J1/12345X/toggle-direct-charging/status/123456"
+      ),
       networkRoute.vehicleToggleDirectChargingRemoteCommandStatusURL(
         vin: vin,
         remoteCommand: RemoteCommandAccepted(requestId: "123456")))
     XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/12345X/toggle-direct-climatisation/true"),
+      URL(
+        string:
+          "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/12345X/toggle-direct-climatisation/true"
+      ),
       networkRoute.vehicleToggleDirectClimatisationURL(vin: vin, enable: true))
     XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/12345X/toggle-direct-climatisation/false"),
+      URL(
+        string:
+          "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/12345X/toggle-direct-climatisation/false"
+      ),
       networkRoute.vehicleToggleDirectClimatisationURL(vin: vin, enable: false))
     XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/12345X/toggle-direct-climatisation/status/123456"),
+      URL(
+        string:
+          "http://localhost:\(kTestServerPort)/e-mobility/ie/en_IE/12345X/toggle-direct-climatisation/status/123456"
+      ),
       networkRoute.vehicleToggleDirectClimatisationRemoteCommandStatusURL(
         vin: vin,
         remoteCommand: RemoteCommandAccepted(requestId: "123456")))
     XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/remote-lock-unlock/12345X/quick-lock"),
+      URL(
+        string:
+          "http://localhost:\(kTestServerPort)/service-vehicle/remote-lock-unlock/12345X/quick-lock"
+      ),
       networkRoute.vehicleLockUnlockURL(vin: vin, lock: true))
     XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/remote-lock-unlock/12345X/security-pin/unlock"),
+      URL(
+        string:
+          "http://localhost:\(kTestServerPort)/service-vehicle/remote-lock-unlock/12345X/security-pin/unlock"
+      ),
       networkRoute.vehicleLockUnlockURL(vin: vin, lock: false))
     XCTAssertEqual(
-      URL(string: "http://localhost:\(kTestServerPort)/service-vehicle/remote-lock-unlock/12345X/123456/status"),
+      URL(
+        string:
+          "http://localhost:\(kTestServerPort)/service-vehicle/remote-lock-unlock/12345X/123456/status"
+      ),
       networkRoute.vehicleLockUnlockRemoteCommandStatusURL(
         vin: vin, remoteCommand: RemoteCommandAccepted(requestId: "123456")))
   }

--- a/Tests/PorscheConnectTests/Public/PorscheConnect+CarControlTests.swift
+++ b/Tests/PorscheConnectTests/Public/PorscheConnect+CarControlTests.swift
@@ -19,8 +19,9 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     super.setUp()
     connect = PorscheConnect(
       username: "homer.simpson@icloud.example", password: "Duh!", environment: .test)
-    connect.authStorage.storeAuthentication(token: OAuthToken(authResponse: kTestPorschePortalAuth),
-                                            for: application.clientId)
+    connect.authStorage.storeAuthentication(
+      token: OAuthToken(authResponse: kTestPorschePortalAuth),
+      for: application.clientId)
   }
 
   // MARK: - Summary Tests

--- a/Tests/PorscheConnectTests/Public/PorscheConnect+CarControlTests.swift
+++ b/Tests/PorscheConnectTests/Public/PorscheConnect+CarControlTests.swift
@@ -10,7 +10,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
   var connect: PorscheConnect!
   let mockNetworkRoutes = MockNetworkRoutes()
   let application: OAuthApplication = .carControl
-  let vehicle = Vehicle(vin: "A1234")
+  let vin = "A1234"
   let capabilites = buildCapabilites()
 
   // MARK: - Lifecycle
@@ -36,7 +36,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: application))
 
-    let result = try! await connect.summary(vehicle: vehicle)
+    let result = try! await connect.summary(vin: vin)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -52,7 +52,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssert(connect.authorized(application: application))
 
-    let result = try! await connect.summary(vehicle: vehicle)
+    let result = try! await connect.summary(vin: vin)
 
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
@@ -70,7 +70,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssert(connect.authorized(application: application))
 
     do {
-      _ = try await connect.summary(vehicle: vehicle)
+      _ = try await connect.summary(vin: vin)
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -88,7 +88,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.summary(vehicle: vehicle)
+      _ = try await connect.summary(vin: vin)
     } catch {
       expectation.fulfill()
       XCTAssertFalse(connect.authorized(application: application))
@@ -110,7 +110,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: application))
 
-    let result = try! await connect.position(vehicle: vehicle)
+    let result = try! await connect.position(vin: vin)
 
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
@@ -127,7 +127,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssert(connect.authorized(application: application))
 
-    let result = try! await connect.position(vehicle: vehicle)
+    let result = try! await connect.position(vin: vin)
 
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
@@ -144,7 +144,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssert(connect.authorized(application: application))
 
     do {
-      _ = try await connect.position(vehicle: vehicle)
+      _ = try await connect.position(vin: vin)
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -162,7 +162,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.position(vehicle: vehicle)
+      _ = try await connect.position(vin: vin)
     } catch {
       expectation.fulfill()
       XCTAssertFalse(connect.authorized(application: application))
@@ -184,7 +184,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: application))
 
-    let result = try! await connect.capabilities(vehicle: vehicle)
+    let result = try! await connect.capabilities(vin: vin)
 
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
@@ -201,7 +201,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssert(connect.authorized(application: application))
 
-    let result = try! await connect.capabilities(vehicle: vehicle)
+    let result = try! await connect.capabilities(vin: vin)
 
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
@@ -219,7 +219,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssert(connect.authorized(application: application))
 
     do {
-      _ = try await connect.capabilities(vehicle: vehicle)
+      _ = try await connect.capabilities(vin: vin)
     } catch {
       expectation.fulfill()
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
@@ -236,7 +236,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.capabilities(vehicle: vehicle)
+      _ = try await connect.capabilities(vin: vin)
     } catch {
       expectation.fulfill()
       XCTAssertFalse(connect.authorized(application: application))
@@ -259,7 +259,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: .api))
 
-    let result = try! await connect.status(vehicle: vehicle)
+    let result = try! await connect.status(vin: vin)
 
     expectation.fulfill()
     XCTAssert(connect.authorized(application: .api))
@@ -279,7 +279,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: .api))
 
     do {
-      _ = try await connect.status(vehicle: vehicle)
+      _ = try await connect.status(vin: vin)
     } catch {
       expectation.fulfill()
       XCTAssertFalse(connect.authorized(application: .api))
@@ -301,7 +301,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: application))
 
-    let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+    let result = try! await connect.emobility(vin: vin, capabilities: capabilites)
 
     expectation.fulfill()
     XCTAssertNotNil(result.response)
@@ -317,7 +317,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssert(connect.authorized(application: application))
 
-    let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+    let result = try! await connect.emobility(vin: vin, capabilities: capabilites)
 
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
@@ -333,7 +333,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssert(connect.authorized(application: application))
 
-    let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+    let result = try! await connect.emobility(vin: vin, capabilities: capabilites)
 
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
@@ -350,7 +350,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssert(connect.authorized(application: application))
 
-    let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+    let result = try! await connect.emobility(vin: vin, capabilities: capabilites)
 
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
@@ -367,7 +367,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssert(connect.authorized(application: application))
 
-    let result = try! await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+    let result = try! await connect.emobility(vin: vin, capabilities: capabilites)
 
     expectation.fulfill()
     XCTAssert(connect.authorized(application: application))
@@ -385,7 +385,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssert(connect.authorized(application: application))
 
     do {
-      _ = try await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+      _ = try await connect.emobility(vin: vin, capabilities: capabilites)
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -404,7 +404,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.emobility(vehicle: vehicle, capabilities: capabilites)
+      _ = try await connect.emobility(vin: vin, capabilities: capabilites)
     } catch {
       expectation.fulfill()
       XCTAssertFalse(connect.authorized(application: application))
@@ -427,7 +427,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: application))
 
-    let result = try! await connect.flash(vehicle: vehicle)
+    let result = try! await connect.flash(vin: vin)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -451,7 +451,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.flash(vehicle: vehicle)
+      _ = try await connect.flash(vin: vin)
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -472,7 +472,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: application))
 
-    let result = try! await connect.flash(vehicle: vehicle, andHonk: true)
+    let result = try! await connect.flash(vin: vin, andHonk: true)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -496,7 +496,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.flash(vehicle: vehicle, andHonk: true)
+      _ = try await connect.flash(vin: vin, andHonk: true)
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -520,7 +520,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     let result = try! await connect.toggleDirectCharging(
-      vehicle: vehicle, capabilities: capabilites)
+      vin: vin, capabilities: capabilites)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -545,7 +545,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     let result = try! await connect.toggleDirectCharging(
-      vehicle: vehicle, capabilities: capabilites, enable: false)
+      vin: vin, capabilities: capabilites, enable: false)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -570,7 +570,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.toggleDirectCharging(vehicle: vehicle, capabilities: capabilites)
+      _ = try await connect.toggleDirectCharging(vin: vin, capabilities: capabilites)
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -593,7 +593,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     do {
       _ = try await connect.toggleDirectCharging(
-        vehicle: vehicle, capabilities: capabilites, enable: false)
+        vin: vin, capabilities: capabilites, enable: false)
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -616,7 +616,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: application))
 
-    let result = try! await connect.lock(vehicle: vehicle)
+    let result = try! await connect.lock(vin: vin)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -640,7 +640,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.lock(vehicle: vehicle)
+      _ = try await connect.lock(vin: vin)
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -663,7 +663,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
     XCTAssertFalse(connect.authorized(application: application))
 
-    let result = try! await connect.unlock(vehicle: vehicle, pin: "1234")
+    let result = try! await connect.unlock(vin: vin, pin: "1234")
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -687,7 +687,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.unlock(vehicle: vehicle, pin: "1234")
+      _ = try await connect.unlock(vin: vin, pin: "1234")
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -709,7 +709,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.unlock(vehicle: vehicle, pin: "1234")
+      _ = try await connect.unlock(vin: vin, pin: "1234")
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))
@@ -731,7 +731,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     XCTAssertFalse(connect.authorized(application: application))
 
     do {
-      _ = try await connect.unlock(vehicle: vehicle, pin: "1234")
+      _ = try await connect.unlock(vin: vin, pin: "1234")
     } catch {
       expectation.fulfill()
       XCTAssert(connect.authorized(application: application))


### PR DESCRIPTION
This removes the need to have an instance of a Vehicle in order to call the APIs, and is particularly handy in cases where you may want to make network requests but you only have a VIN available (e.g. when being used as a key in a dictionary).

This is a breaking change. Fixing it is often just a matter of replacing `vehicle: vehicle` with `vin: vehicle.vin` or `vin: vin` if you already have the vin as a variable.