### PR TITLE
Move the supported locale logic into the core library.

### DIFF
--- a/Sources/CommandLineTool/Porsche.swift
+++ b/Sources/CommandLineTool/Porsche.swift
@@ -4,6 +4,10 @@ import PorscheConnect
 
 // MARK: - Main
 
+// Allow SupportedLocale to be used as a command line option.
+extension SupportedLocale: ExpressibleByArgument {
+}
+
 @main
 struct Porsche: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
@@ -25,63 +29,19 @@ struct Porsche: AsyncParsableCommand {
     @Argument(help: ArgumentHelp(NSLocalizedString("Your MyPorsche password.", comment: "")))
     var password: String
 
-    // The list of supported locales was determined via brute force authorization attempts using
-    // the following code:
-    //
-    //    let identifiers = Locale.availableIdentifiers
-    //    for identifier in identifiers {
-    //      guard let environment = Environment(locale: Locale(identifier: identifier)) else {
-    //        continue
-    //      }
-    //      let porscheConnect = PorscheConnect(
-    //        username: options.username,
-    //        password: options.password,
-    //        environment: environment
-    //      )
-    //      await callListVehiclesService(porscheConnect: porscheConnect)
-    //    }
-    enum LocaleOption: String, ExpressibleByArgument, CaseIterable {
-      case china = "zh_CN"
-      case czechia = "cs_CZ"
-      case denmark = "da_DK"
-      case estonia = "et_EE"
-      case finland = "fi_FI"
-      case france = "fr_FR"
-      case germany = "de_DE"
-      case italy = "it_IT"
-      case japan = "ja_JP"
-      case korea = "ko_KR"
-      case latvia = "lv_LV"
-      case lithuania = "lt_LT"
-      case netherlands = "nl_NL"
-      case poland = "pl_PL"
-      case portugal = "pt_PT"
-      case russia = "ru_RU"
-      case spain = "es_ES"
-      case sweden = "sv_SE"
-      case taiwan = "zh_TW"
-      case turkey = "tr_TR"
-      case unitedKingdom = "en_GB"
-      case unitedStates = "en_US"
-    }
     @Option(help: ArgumentHelp(NSLocalizedString(
       "The locale to use when making API calls. "
       + "Defaults to the system locale if possible, otherwise defaults to Germany. ",
       comment: ""
     )))
-    var locale: LocaleOption? = nil
+    var locale: SupportedLocale? = nil
 
     private var resolvedLocale: Locale {
       // Prioritize the provided locale option, if one was given.
       if let givenLocale = locale {
         return Locale(identifier: givenLocale.rawValue)
       }
-      // If no locale was provided, try to use the user's current locale.
-      if let currentLocale = LocaleOption(rawValue: Locale.current.identifier) {
-        return Locale(identifier: currentLocale.rawValue)
-      }
-      // If the system locale wasn't supported at all, fall back to Germany.
-      return Locale(identifier: LocaleOption.germany.rawValue)
+      return SupportedLocale.default
     }
 
     var resolvedEnvironment: Environment {

--- a/Sources/PorscheConnect/Environment.swift
+++ b/Sources/PorscheConnect/Environment.swift
@@ -29,3 +29,54 @@ public struct Environment: Equatable {
   static public let germany = Environment(locale: Locale(identifier: "de_DE"))!
   static let test = Environment(locale: Locale(identifier: "en_IE"))!
 }
+
+/// The set of locales known to be supported by the Porsche API endpoints.
+///
+/// The list of supported locales was determined via brute force authorization attempts using
+/// the following code:
+///
+///    let identifiers = Locale.availableIdentifiers
+///    for identifier in identifiers {
+///      guard let environment = Environment(locale: Locale(identifier: identifier)) else {
+///        continue
+///      }
+///      let porscheConnect = PorscheConnect(
+///        username: options.username,
+///        password: options.password,
+///        environment: environment
+///      )
+///      await callListVehiclesService(porscheConnect: porscheConnect)
+///    }
+public enum SupportedLocale: String, CaseIterable {
+  case china = "zh_CN"
+  case czechia = "cs_CZ"
+  case denmark = "da_DK"
+  case estonia = "et_EE"
+  case finland = "fi_FI"
+  case france = "fr_FR"
+  case germany = "de_DE"
+  case italy = "it_IT"
+  case japan = "ja_JP"
+  case korea = "ko_KR"
+  case latvia = "lv_LV"
+  case lithuania = "lt_LT"
+  case netherlands = "nl_NL"
+  case poland = "pl_PL"
+  case portugal = "pt_PT"
+  case russia = "ru_RU"
+  case spain = "es_ES"
+  case sweden = "sv_SE"
+  case taiwan = "zh_TW"
+  case turkey = "tr_TR"
+  case unitedKingdom = "en_GB"
+  case unitedStates = "en_US"
+
+  public static var `default`: Locale {
+    // If no locale was provided, try to use the user's current locale.
+    if let currentLocale = SupportedLocale(rawValue: Locale.current.identifier) {
+      return Locale(identifier: currentLocale.rawValue)
+    }
+    // If the system locale wasn't supported at all, fall back to Germany.
+    return Locale(identifier: SupportedLocale.germany.rawValue)
+  }
+}


### PR DESCRIPTION
This will enable it to be reused in other contexts than the CLI.