### PR TITLE
Allow auth token storage to be async.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
     .package(url: "https://github.com/envoy/Embassy.git", from: "4.1.4"),
     .package(url: "https://github.com/envoy/Ambassador.git", from: "4.0.5"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
+    .package(url: "https://github.com/mochidev/XCTAsync.git", .upToNextMajor(from: "1.0.0")),
   ],
   targets: [
     .executableTarget(
@@ -34,6 +35,11 @@ let package = Package(
       dependencies: []),
     .testTarget(
       name: "PorscheConnectTests",
-      dependencies: ["PorscheConnect", "Embassy", "Ambassador"]),
+      dependencies: [
+        "PorscheConnect",
+        "Embassy",
+        "Ambassador",
+        "XCTAsync"
+      ]),
   ]
 )

--- a/Sources/PorscheConnect/Foundations/OAuth/AuthStoring.swift
+++ b/Sources/PorscheConnect/Foundations/OAuth/AuthStoring.swift
@@ -3,8 +3,8 @@ import Foundation
 /// A type that is able to handle storage and retrieval of OAuth authentication tokens.
 public protocol AuthStoring {
   /// Asks the receiver to store the given OAuthToken with the given key.
-  func storeAuthentication(token: OAuthToken?, for key: String)
+  func storeAuthentication(token: OAuthToken?, for key: String) async throws
 
   /// Asks the receiver to return an OAuthToken, if one exists, for the given key.
-  func authentication(for key: String) -> OAuthToken?
+  func authentication(for key: String) async -> OAuthToken?
 }

--- a/Sources/PorscheConnect/PorscheConnect+Auth.swift
+++ b/Sources/PorscheConnect/PorscheConnect+Auth.swift
@@ -20,7 +20,7 @@ extension PorscheConnect {
 
       return OAuthToken(authResponse: porscheAuth)
     }
-    authStorage.storeAuthentication(token: token, for: application.clientId)
+    try await authStorage.storeAuthentication(token: token, for: application.clientId)
     return token
   }
 

--- a/Sources/PorscheConnect/PorscheConnect.swift
+++ b/Sources/PorscheConnect/PorscheConnect.swift
@@ -78,8 +78,8 @@ public class PorscheConnect {
 
   // MARK: - Common functions
 
-  func authorized(application: OAuthApplication) -> Bool {
-    guard let auth = authStorage.authentication(for: application.clientId) else {
+  func authorized(application: OAuthApplication) async -> Bool {
+    guard let auth = await authStorage.authentication(for: application.clientId) else {
       return false
     }
 
@@ -91,7 +91,7 @@ public class PorscheConnect {
   internal func performAuthFor(application: OAuthApplication) async throws -> [String: String] {
     _ = try await authIfRequired(application: application)
 
-    guard let auth = authStorage.authentication(for: application.clientId), let apiKey = auth.apiKey else {
+    guard let auth = await authStorage.authentication(for: application.clientId), let apiKey = auth.apiKey else {
       throw PorscheConnectError.AuthFailure
     }
 
@@ -106,7 +106,7 @@ public class PorscheConnect {
   // MARK: - Private functions
 
   private func authIfRequired(application: OAuthApplication) async throws {
-    if !authorized(application: application) {
+    if await !authorized(application: application) {
       do {
         _ = try await auth(application: application)
       } catch {

--- a/Tests/PorscheConnectTests/Public/PorscheConnect+AuthTests.swift
+++ b/Tests/PorscheConnectTests/Public/PorscheConnect+AuthTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import func XCTAsync.XCTAssertFalse
+import func XCTAsync.XCTAssertTrue
 
 @testable import PorscheConnect
 
@@ -26,11 +28,11 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
     let porscheAuth = try! await connect.auth(application: application)
     expectation.fulfill()
 
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
     assertCookiesPresent()
 
     XCTAssertNotNil(porscheAuth)
@@ -41,7 +43,8 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
     XCTAssertEqual("Bearer", porscheAuth.tokenType)
     XCTAssertGreaterThan(porscheAuth.expiresAt, Date())
 
-    let portalAuth = try XCTUnwrap(connect.authStorage.authentication(for: application.clientId))
+    let auth = await connect.authStorage.authentication(for: application.clientId)
+    let portalAuth = try XCTUnwrap(auth)
 
     XCTAssertEqual("Kpjg2m1ZXd8GM0pvNIB3jogWd0o6", portalAuth.accessToken)
     XCTAssertEqual(
@@ -58,14 +61,14 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.auth(application: application)
     } catch {
       expectation.fulfill()
 
-      XCTAssertFalse(connect.authorized(application: application))
+      await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
       assertCookiesNotPresent()
     }
 
@@ -78,13 +81,13 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.auth(application: application)
     } catch {
       expectation.fulfill()
-      XCTAssertFalse(connect.authorized(application: application))
+      await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
       assertCookiesPresent()
     }
 
@@ -98,13 +101,13 @@ final class PorscheConnectAuthTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.auth(application: application)
     } catch {
       expectation.fulfill()
-      XCTAssertFalse(connect.authorized(application: application))
+      await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
       assertCookiesPresent()
     }
 

--- a/Tests/PorscheConnectTests/Public/PorscheConnect+CarControlTests.swift
+++ b/Tests/PorscheConnectTests/Public/PorscheConnect+CarControlTests.swift
@@ -1,5 +1,7 @@
 import Ambassador
 import XCTest
+import func XCTAsync.XCTAssertFalse
+import func XCTAsync.XCTAssertTrue
 
 @testable import PorscheConnect
 
@@ -15,19 +17,19 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
   // MARK: - Lifecycle
 
-  override func setUp() {
-    super.setUp()
+  override func setUp() async throws {
+    try await super.setUp()
     connect = PorscheConnect(
       username: "homer.simpson@icloud.example", password: "Duh!", environment: .test)
-    connect.authStorage.storeAuthentication(
+    try await connect.authStorage.storeAuthentication(
       token: OAuthToken(authResponse: kTestPorschePortalAuth),
       for: application.clientId)
   }
 
   // MARK: - Summary Tests
 
-  func testSummaryAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testSummaryAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -35,7 +37,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetSummarySuccessful(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.summary(vin: vin)
 
@@ -47,16 +49,16 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testSummaryNoAuthRequiredSuccessful() async {
+  func testSummaryNoAuthRequiredSuccessful() async throws {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetSummarySuccessful(router: router)
 
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
 
     let result = try! await connect.summary(vin: vin)
 
     expectation.fulfill()
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
     XCTAssertNotNil(result)
     XCTAssertNotNil(result.summary)
     assertSummary(result.summary!)
@@ -64,35 +66,35 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testSummaryNoAuthRequiredFailure() async {
+  func testSummaryNoAuthRequiredFailure() async throws {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetSummaryFailure(router: router)
 
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
 
     do {
       _ = try await connect.summary(vin: vin)
     } catch {
       expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
+      await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testSummaryAuthRequiredAuthFailure() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testSummaryAuthRequiredAuthFailure() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.summary(vin: vin)
     } catch {
       expectation.fulfill()
-      XCTAssertFalse(connect.authorized(application: application))
+      await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
       XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
     }
 
@@ -101,20 +103,20 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
   // MARK: - Position Tests
 
-  func testPositionAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testPositionAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetPositionSuccessful(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.position(vin: vin)
 
     expectation.fulfill()
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
     XCTAssertNotNil(result.response)
     XCTAssertNotNil(result.position)
     assertPosition(result.position!)
@@ -122,51 +124,51 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testPositionNoAuthRequiredSuccessful() async {
+  func testPositionNoAuthRequiredSuccessful() async throws {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetPositionSuccessful(router: router)
 
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
 
     let result = try! await connect.position(vin: vin)
 
     expectation.fulfill()
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
     XCTAssertNotNil(result.response)
     XCTAssertNotNil(result.position)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testPositionNoAuthRequiredFailure() async {
+  func testPositionNoAuthRequiredFailure() async throws {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetPositionFailure(router: router)
 
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
 
     do {
       _ = try await connect.position(vin: vin)
     } catch {
       expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
+      await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testPositionAuthRequiredAuthFailure() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testPositionAuthRequiredAuthFailure() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.position(vin: vin)
     } catch {
       expectation.fulfill()
-      XCTAssertFalse(connect.authorized(application: application))
+      await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
       XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
     }
 
@@ -175,20 +177,20 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
   // MARK: - Capabilities Tests
 
-  func testCapabilitiesAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testCapabilitiesAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetCapabilitiesSuccessful(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.capabilities(vin: vin)
 
     expectation.fulfill()
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
     XCTAssertNotNil(result.response)
     XCTAssertNotNil(result.capabilities)
     assertCapabilities(result.capabilities!)
@@ -196,16 +198,16 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testCapabilitiesNoAuthRequiredSuccessful() async {
+  func testCapabilitiesNoAuthRequiredSuccessful() async throws {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetCapabilitiesSuccessful(router: router)
 
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
 
     let result = try! await connect.capabilities(vin: vin)
 
     expectation.fulfill()
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
     XCTAssertNotNil(result.response)
     XCTAssertNotNil(result.capabilities)
     assertCapabilities(result.capabilities!)
@@ -213,11 +215,11 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testCapabilitiesNoAuthRequiredFailure() async {
+  func testCapabilitiesNoAuthRequiredFailure() async throws {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetCapabilitiesFailure(router: router)
 
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
 
     do {
       _ = try await connect.capabilities(vin: vin)
@@ -229,18 +231,18 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testCapabilitiesAuthRequiredAuthFailure() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testCapabilitiesAuthRequiredAuthFailure() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.capabilities(vin: vin)
     } catch {
       expectation.fulfill()
-      XCTAssertFalse(connect.authorized(application: application))
+      await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
       XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
     }
 
@@ -249,21 +251,21 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
   // MARK: - Status Tests
 
-  func testStatusAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
-    connect.authStorage.storeAuthentication(token: nil, for: OAuthApplication.api.clientId)
+  func testStatusAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+    try await connect.authStorage.storeAuthentication(token: nil, for: OAuthApplication.api.clientId)
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetStatusSuccessful(router: router)
 
-    XCTAssertFalse(connect.authorized(application: .api))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: .api))
 
     let result = try! await connect.status(vin: vin)
 
     expectation.fulfill()
-    XCTAssert(connect.authorized(application: .api))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: .api))
     XCTAssertNotNil(result.response)
     XCTAssertNotNil(result.status)
     assertStatus(result.status!)
@@ -271,19 +273,19 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testStatusAuthRequiredAuthFailure() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
-    connect.authStorage.storeAuthentication(token: nil, for: OAuthApplication.api.clientId)
+  func testStatusAuthRequiredAuthFailure() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+    try await connect.authStorage.storeAuthentication(token: nil, for: OAuthApplication.api.clientId)
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: .api))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: .api))
 
     do {
       _ = try await connect.status(vin: vin)
     } catch {
       expectation.fulfill()
-      XCTAssertFalse(connect.authorized(application: .api))
+      await XCTAsync.XCTAssertFalse(await connect.authorized(application: .api))
       XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
     }
 
@@ -292,15 +294,15 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
   // MARK: - Emobility Tests
 
-  func testEmobilityAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testEmobilityAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
     mockNetworkRoutes.mockGetApiAuthSuccessful(router: router)
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetEmobilityNotChargingSuccessful(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.emobility(vin: vin, capabilities: capabilites)
 
@@ -312,32 +314,32 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testEmobilityNotChargingNoAuthRequiredSuccessful() async {
+  func testEmobilityNotChargingNoAuthRequiredSuccessful() async throws {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetEmobilityNotChargingSuccessful(router: router)
 
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
 
     let result = try! await connect.emobility(vin: vin, capabilities: capabilites)
 
     expectation.fulfill()
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
     XCTAssertNotNil(result.response)
     XCTAssertNotNil(result.emobility)
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testEmobilityACTimerChargingNoAuthRequiredSuccessful() async {
+  func testEmobilityACTimerChargingNoAuthRequiredSuccessful() async throws {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetEmobilityACTimerChargingSuccessful(router: router)
 
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
 
     let result = try! await connect.emobility(vin: vin, capabilities: capabilites)
 
     expectation.fulfill()
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
     XCTAssertNotNil(result.response)
     XCTAssertNotNil(result.emobility)
     assertEmobilityWhenACTimerCharging(result.emobility!)
@@ -345,16 +347,16 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testEmobilityACDirectChargingNoAuthRequiredSuccessful() async {
+  func testEmobilityACDirectChargingNoAuthRequiredSuccessful() async throws {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetEmobilityACDirectChargingSuccessful(router: router)
 
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
 
     let result = try! await connect.emobility(vin: vin, capabilities: capabilites)
 
     expectation.fulfill()
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
     XCTAssertNotNil(result.response)
     XCTAssertNotNil(result.emobility)
     assertEmobilityWhenACDirectCharging(result.emobility!)
@@ -362,16 +364,16 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testEmobilityDCChargingNoAuthRequiredSuccessful() async {
+  func testEmobilityDCChargingNoAuthRequiredSuccessful() async throws {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetEmobilityDCChargingSuccessful(router: router)
 
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
 
     let result = try! await connect.emobility(vin: vin, capabilities: capabilites)
 
     expectation.fulfill()
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
     XCTAssertNotNil(result.response)
     XCTAssertNotNil(result.emobility)
     assertEmobilityWhenDCCharging(result.emobility!)
@@ -379,36 +381,36 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testEmobilityNoAuthRequiredFailure() async {
+  func testEmobilityNoAuthRequiredFailure() async throws {
     let expectation = expectation(description: "Network Expectation")
     mockNetworkRoutes.mockGetEmobilityFailure(router: router)
 
-    XCTAssert(connect.authorized(application: application))
+    await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
 
     do {
       _ = try await connect.emobility(vin: vin, capabilities: capabilites)
     } catch {
       expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
+      await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testEmobilityAuthRequiredAuthFailure() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testEmobilityAuthRequiredAuthFailure() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.emobility(vin: vin, capabilities: capabilites)
     } catch {
       expectation.fulfill()
-      XCTAssertFalse(connect.authorized(application: application))
+      await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
       XCTAssertEqual(PorscheConnectError.AuthFailure, error as! PorscheConnectError)
     }
 
@@ -417,8 +419,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
   // MARK: - Honk and Flash Tests
 
-  func testFlashAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testFlashAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -426,7 +428,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostFlashSuccessful(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.flash(vin: vin)
 
@@ -440,8 +442,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testFlashAuthRequiredFailure() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testFlashAuthRequiredFailure() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -449,21 +451,21 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostFlashFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.flash(vin: vin)
     } catch {
       expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
+      await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testHonkAndFlashAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testHonkAndFlashAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -471,7 +473,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostHonkAndFlashSuccessful(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.flash(vin: vin, andHonk: true)
 
@@ -485,8 +487,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testHonkAndFlashAuthRequiredFailure() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testHonkAndFlashAuthRequiredFailure() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -494,13 +496,13 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostHonkAndFlashFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.flash(vin: vin, andHonk: true)
     } catch {
       expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
+      await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
 
@@ -509,8 +511,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
   // MARK: - Toggle Direct Charging Tests
 
-  func testToggleDirectChargingOnAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testToggleDirectChargingOnAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -518,7 +520,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostToggleDirectChargingOnSuccessful(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.toggleDirectCharging(
       vin: vin, capabilities: capabilites)
@@ -534,8 +536,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testToggleDirectChargingOffAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testToggleDirectChargingOffAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -543,7 +545,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostToggleDirectChargingOffSuccessful(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.toggleDirectCharging(
       vin: vin, capabilities: capabilites, enable: false)
@@ -559,8 +561,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testToggleDirectChargingOnFailureAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testToggleDirectChargingOnFailureAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -568,21 +570,21 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostToggleDirectChargingOnFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.toggleDirectCharging(vin: vin, capabilities: capabilites)
     } catch {
       expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
+      await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testToggleDirectChargingOffFailureAuthRequired() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testToggleDirectChargingOffFailureAuthRequired() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -590,14 +592,14 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostToggleDirectChargingOffFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.toggleDirectCharging(
         vin: vin, capabilities: capabilites, enable: false)
     } catch {
       expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
+      await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
 
@@ -606,8 +608,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
   // MARK: - Lock Vehicle
 
-  func testLockVehicleSuccessfulAuthRequired() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testLockVehicleSuccessfulAuthRequired() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -615,7 +617,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostLockSuccessful(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.lock(vin: vin)
 
@@ -629,8 +631,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testLockVehicleFailureAuthRequired() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testLockVehicleFailureAuthRequired() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -638,13 +640,13 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockPostLockFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.lock(vin: vin)
     } catch {
       expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
+      await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
 
@@ -653,8 +655,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
 
   // MARK: - Unlock Vehicle
 
-  func testUnlockVehicleSuccessfulAuthRequired() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testUnlockVehicleSuccessfulAuthRequired() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -662,7 +664,7 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetPostUnlockSuccessful(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.unlock(vin: vin, pin: "1234")
 
@@ -676,8 +678,8 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testUnlockVehicleFailureAuthRequired() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testUnlockVehicleFailureAuthRequired() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -685,21 +687,21 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetPostUnlockFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.unlock(vin: vin, pin: "1234")
     } catch {
       expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
+      await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
       XCTAssertEqual(HttpStatusCode.BadRequest, error as! HttpStatusCode)
     }
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testUnlockVehicleLockedErrorAuthRequired() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testUnlockVehicleLockedErrorAuthRequired() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -707,21 +709,21 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetPostUnlockLockedError(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.unlock(vin: vin, pin: "1234")
     } catch {
       expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
+      await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
       XCTAssertEqual(PorscheConnectError.lockedFor60Minutes, error as! PorscheConnectError)
     }
 
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testUnlockVehicleIncorrectPinErrorAuthRequired() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testUnlockVehicleIncorrectPinErrorAuthRequired() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let expectation = expectation(description: "Network Expectation")
 
     mockNetworkRoutes.mockPostLoginAuthSuccessful(router: router)
@@ -729,13 +731,13 @@ final class PorscheConnectCarControlTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetPostUnlockIncorrectPinError(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     do {
       _ = try await connect.unlock(vin: vin, pin: "1234")
     } catch {
       expectation.fulfill()
-      XCTAssert(connect.authorized(application: application))
+      await XCTAsync.XCTAssertTrue(await connect.authorized(application: application))
       XCTAssertEqual(PorscheConnectError.IncorrectPin, error as! PorscheConnectError)
     }
 

--- a/Tests/PorscheConnectTests/Public/PorscheConnect+RemoteCommandStatusTests.swift
+++ b/Tests/PorscheConnectTests/Public/PorscheConnect+RemoteCommandStatusTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import func XCTAsync.XCTAssertFalse
 
 @testable import PorscheConnect
 
@@ -13,18 +14,20 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
   // MARK: - Lifecycle
 
-  override func setUp() {
-    super.setUp()
+  override func setUp() async throws {
+    try await super.setUp()
     connect = PorscheConnect(
       username: "homer.simpson@icloud.example", password: "Duh!", environment: .test)
-    connect.authStorage.storeAuthentication(token: OAuthToken(authResponse: kTestPorschePortalAuth),
-                                            for: application.clientId)
+    try await connect.authStorage.storeAuthentication(
+      token: OAuthToken(authResponse: kTestPorschePortalAuth),
+      for: application.clientId
+    )
   }
 
   // MARK: - Honk and Flash Tests
 
-  func testRemoteCommandHonkAndFlashStatusInProgressAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandHonkAndFlashStatusInProgressAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(id: "999", lastUpdated: Date(), remoteCommand: .honkAndFlash)
     let expectation = expectation(description: "Network Expectation")
 
@@ -33,7 +36,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetHonkAndFlashRemoteCommandStatusInProgress(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -45,8 +48,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testRemoteCommandHonkAndFlashStatusSuccessAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandHonkAndFlashStatusSuccessAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(id: "999", lastUpdated: Date(), remoteCommand: .honkAndFlash)
     let expectation = expectation(description: "Network Expectation")
 
@@ -55,7 +58,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetHonkAndFlashRemoteCommandStatusSuccess(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -67,8 +70,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testRemoteCommandHonkAndFlashStatusFailureAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandHonkAndFlashStatusFailureAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(id: "999", lastUpdated: Date(), remoteCommand: .honkAndFlash)
     let expectation = expectation(description: "Network Expectation")
 
@@ -77,7 +80,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetHonkAndFlashRemoteCommandStatusFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -93,8 +96,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
   // MARK: - Toggle Direct Charging Tests
 
-  func testRemoteCommandToggleDirectChargingStatusInProgressAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandToggleDirectChargingStatusInProgressAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .toggleDirectCharge)
     let expectation = expectation(description: "Network Expectation")
 
@@ -103,7 +106,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetToggleDirectChargingRemoteCommandStatusInProgress(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -115,8 +118,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testRemoteCommandToggleDirectChargingStatusSuccessAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandToggleDirectChargingStatusSuccessAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .toggleDirectCharge)
     let expectation = expectation(description: "Network Expectation")
 
@@ -125,7 +128,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetToggleDirectChargingRemoteCommandStatusSuccess(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -137,8 +140,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testRemoteCommandToggleDirectChargingStatusFailureAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandToggleDirectChargingStatusFailureAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .toggleDirectCharge)
     let expectation = expectation(description: "Network Expectation")
 
@@ -147,7 +150,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetToggleDirectChargingRemoteCommandStatusFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -163,8 +166,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
   // MARK: - Toggle Direct Climatisation Tests
 
-  func testRemoteCommandToggleDirectClimatisationStatusInProgressAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandToggleDirectClimatisationStatusInProgressAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .toggleDirectClimatisation)
     let expectation = expectation(description: "Network Expectation")
 
@@ -173,7 +176,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetToggleDirectClimatisationRemoteCommandStatusInProgress(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -185,8 +188,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testRemoteCommandToggleDirectClimatisationStatusSuccessAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandToggleDirectClimatisationStatusSuccessAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .toggleDirectClimatisation)
     let expectation = expectation(description: "Network Expectation")
 
@@ -195,7 +198,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetToggleDirectClimatisationRemoteCommandStatusSuccess(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -207,8 +210,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testRemoteCommandToggleDirectClimatisationStatusFailureAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandToggleDirectClimatisationStatusFailureAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .toggleDirectClimatisation)
     let expectation = expectation(description: "Network Expectation")
 
@@ -217,7 +220,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetToggleDirectClimatisationRemoteCommandStatusFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -233,8 +236,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
   
   // MARK: - Lock Tests
 
-  func testRemoteCommandLockStatusInProgressAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandLockStatusInProgressAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .lock)
     let expectation = expectation(description: "Network Expectation")
 
@@ -243,7 +246,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetLockUnlockRemoteCommandStatusInProgress(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -255,8 +258,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testRemoteCommandLockStatusSuccessfulAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandLockStatusSuccessfulAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .lock)
     let expectation = expectation(description: "Network Expectation")
 
@@ -265,7 +268,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetLockUnlockRemoteCommandStatusSuccess(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -277,8 +280,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testRemoteCommandLockStatusFailureAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandLockStatusFailureAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .lock)
     let expectation = expectation(description: "Network Expectation")
 
@@ -287,7 +290,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetLockUnlockRemoteCommandStatusFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -303,8 +306,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
   // MARK: - Unlock Tests
 
-  func testRemoteCommandUnlockStatusInProgressAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandUnlockStatusInProgressAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .lock)
     let expectation = expectation(description: "Network Expectation")
 
@@ -313,7 +316,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetLockUnlockRemoteCommandStatusInProgress(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -325,8 +328,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testRemoteCommandUnlockStatusSuccessfulAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandUnlockStatusSuccessfulAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .lock)
     let expectation = expectation(description: "Network Expectation")
 
@@ -335,7 +338,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetLockUnlockRemoteCommandStatusSuccess(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 
@@ -347,8 +350,8 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     await waitForExpectations(timeout: kDefaultTestTimeout, handler: nil)
   }
 
-  func testRemoteCommandUnlockStatusFailureAuthRequiredSuccessful() async {
-    connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
+  func testRemoteCommandUnlockStatusFailureAuthRequiredSuccessful() async throws {
+    try await connect.authStorage.storeAuthentication(token: nil, for: application.clientId)
     let remoteCommand = RemoteCommandAccepted(requestId: "999", remoteCommand: .lock)
     let expectation = expectation(description: "Network Expectation")
 
@@ -357,7 +360,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
     mockNetworkRoutes.mockPostApiTokenSuccessful(router: router)
     mockNetworkRoutes.mockGetLockUnlockRemoteCommandStatusFailure(router: router)
 
-    XCTAssertFalse(connect.authorized(application: application))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
     let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
 

--- a/Tests/PorscheConnectTests/Public/PorscheConnectTests.swift
+++ b/Tests/PorscheConnectTests/Public/PorscheConnectTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import func XCTAsync.XCTAssertFalse
 
 @testable import PorscheConnect
 
@@ -19,13 +20,13 @@ final class PorscheConnectTests: BaseMockNetworkTestCase {
 
   // MARK: - Tests
 
-  func testConstruction() {
+  func testConstruction() async {
     XCTAssertNotNil(connect)
     XCTAssertEqual(Environment.test, connect.environment)
     XCTAssertEqual("homer.simpson@icloud.example", connect.username)
     XCTAssertNotNil(connect.authStorage)
-    XCTAssertFalse(connect.authorized(application: .api))
-    XCTAssertFalse(connect.authorized(application: .carControl))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: .api))
+    await XCTAsync.XCTAssertFalse(await connect.authorized(application: .carControl))
   }
 
   func testEnvironmentGermany() {


### PR DESCRIPTION
This will allow the auth storage to be synchronized using the `actor` type.

This change required significant syntactic updates to the tests. Unfortunately, XCTest does not yet support `async`, so a third party library was added to the test target as a shim. If/when Apple adds support for async XCTAssert statements, it should be a simple find-replace operation to update to the modern APIs.