### PR TITLE
Update TimestampFormatter API to match standard API signatures.

### DIFF
--- a/Sources/CommandLineTool/Command+ShowTrips.swift
+++ b/Sources/CommandLineTool/Command+ShowTrips.swift
@@ -56,8 +56,9 @@ extension Porsche {
     }
     
     private func printTrip(_ trip: Trip, at index: Int) {
+      let timestampFormatter = TimestampFormatter()
       let output = NSLocalizedString(
-        "#\(index+1) => Trip ID: \(trip.id); Timestamp: \(TimestampFormatter(timestamp: trip.timestamp).formatted()); Distance: \(trip.tripMileage.valueInKilometers) km; Average speed: \(trip.averageSpeed.valueInKmh) km/h; EV consumption: \(trip.averageElectricEngineConsumption.valueKwhPer100Km) kWh/100km",
+        "#\(index+1) => Trip ID: \(trip.id); Timestamp: \(timestampFormatter.formatted(from: trip.timestamp)!); Distance: \(trip.tripMileage.valueInKilometers) km; Average speed: \(trip.averageSpeed.valueInKmh) km/h; EV consumption: \(trip.averageElectricEngineConsumption.valueKwhPer100Km) kWh/100km",
         comment: "") //TODO: Implement locales for units
       print(output)
     }

--- a/Sources/PorscheConnect/Models/Formatters/TimestampFormatter.swift
+++ b/Sources/PorscheConnect/Models/Formatters/TimestampFormatter.swift
@@ -1,25 +1,33 @@
 import Foundation
 
 public final class TimestampFormatter {
-  
+
   // MARK: - Properties
-  
-  public let timestamp: Date
-  
+
+  public var timeZone: TimeZone {
+    get { formatter.timeZone }
+    set { formatter.timeZone = newValue }
+  }
+  public var locale: Locale {
+    get { formatter.locale }
+    set { formatter.locale = newValue }
+  }
+
   private let formatter = DateFormatter()
-  
+
   // MARK: - Lifecycle
-  
-  public init(timestamp: Date, locale: Locale = .current) {
-    self.timestamp = timestamp
+
+  public init() {
     self.formatter.dateStyle = .medium
     self.formatter.timeStyle = .medium
-    self.formatter.locale = locale
+    self.formatter.timeZone = .autoupdatingCurrent
+    self.formatter.locale = .current
   }
-  
+
   // MARK: - Public functions
-  
-  public func formatted() -> String {
-    return formatter.string(for: timestamp) ?? kBlankString
+
+  public func formatted(from date: Date) -> String? {
+    return formatter.string(for: date)
   }
 }
+

--- a/Tests/PorscheConnectTests/Models/Formatters/TimestampFormatterTests.swift
+++ b/Tests/PorscheConnectTests/Models/Formatters/TimestampFormatterTests.swift
@@ -3,26 +3,35 @@ import XCTest
 @testable import PorscheConnect
 
 final class TimestampFormatterTests: XCTestCase {
- 
+
   let timestamp = ISO8601DateFormatter().date(from: "2023-01-17T20:58:30Z")!
-  
+
   func testFormatterIrelandLocale() {
-    let formatter = TimestampFormatter(timestamp: timestamp, locale: Locale(identifier: "en_IE"))
-    XCTAssertEqual("17 Jan 2023 at 20:58:30", formatter.formatted())
+    let formatter = TimestampFormatter()
+    formatter.locale = Locale(identifier: "en_IE")
+    formatter.timeZone = .init(abbreviation: "GMT")!
+    XCTAssertEqual("17 Jan 2023 at 20:58:30", formatter.formatted(from: timestamp))
   }
-  
+
   func testFormatterUnitedStatesLocale() {
-    let formatter = TimestampFormatter(timestamp: timestamp, locale: Locale(identifier: "en_US"))
-    XCTAssertEqual("Jan 17, 2023 at 8:58:30 PM", formatter.formatted())
+    let formatter = TimestampFormatter()
+    formatter.locale = Locale(identifier: "en_US")
+    formatter.timeZone = .init(abbreviation: "GMT")!
+    XCTAssertEqual("Jan 17, 2023 at 8:58:30 PM", formatter.formatted(from: timestamp))
   }
-  
+
   func testFormatterGermanyLocale() {
-    let formatter = TimestampFormatter(timestamp: timestamp, locale: Locale(identifier: "de_DE"))
-    XCTAssertEqual("17.01.2023, 20:58:30", formatter.formatted())
+    let formatter = TimestampFormatter()
+    formatter.locale = Locale(identifier: "de_DE")
+    formatter.timeZone = .init(abbreviation: "GMT")!
+    XCTAssertEqual("17.01.2023, 20:58:30", formatter.formatted(from: timestamp))
   }
-  
+
   func testFormatterChinaLocale() {
-    let formatter = TimestampFormatter(timestamp: timestamp, locale: Locale(identifier: "zh_CN"))
-    XCTAssertEqual("2023年1月17日 20:58:30", formatter.formatted())
+    let formatter = TimestampFormatter()
+    formatter.locale = Locale(identifier: "zh_CN")
+    formatter.timeZone = .init(abbreviation: "GMT")!
+    XCTAssertEqual("2023年1月17日 20:58:30", formatter.formatted(from: timestamp))
   }
 }
+


### PR DESCRIPTION
Notably, formatters typically:
- are initialized with zero parameters
- expose configurable properties that affect the formatter's behavior
- expose APIs for formatting values into strings.

Also updated the tests to ensure that they're not timezone-dependent.