### PR TITLE
Add status checking to the lock command invocation from the CLI.

### DIFF
--- a/Sources/PorscheConnect/Models/LockUnlockLastActions.swift
+++ b/Sources/PorscheConnect/Models/LockUnlockLastActions.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Status of all doors on the car. Meant to be called after initiating a lock/unlock command.
+public struct LockUnlockLastActions: Codable {
+  public let vin: String
+  public let doors: Doors
+  public let rluResult: Int
+  public let bsError: Int
+}

--- a/Sources/PorscheConnect/Models/Overview.swift
+++ b/Sources/PorscheConnect/Models/Overview.swift
@@ -20,6 +20,7 @@ public struct Overview: Codable {
   public let parkingLight: ParkingLight
   public let tires: Tires
   public let windows: Windows
+  public let doors: Doors
   public let serviceIntervals: ServiceIntervals
   public let overallOpenStatus: PhysicalStatus
 

--- a/Sources/PorscheConnect/Models/Subtypes/Doors.swift
+++ b/Sources/PorscheConnect/Models/Subtypes/Doors.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// The status of all doors on the vehicle.
+public struct Doors: Codable {
+  public let frontLeft: DoorStatus
+  public let frontRight: DoorStatus
+  public let backLeft: DoorStatus
+  public let backRight: DoorStatus
+  public let frontTrunk: DoorStatus
+  public let backTrunk: DoorStatus
+  public let overallLockStatus: DoorStatus
+
+  public enum DoorStatus: String, Codable {
+    case closedAndLocked = "CLOSED_LOCKED"
+    case closedAndUnlocked = "CLOSED_UNLOCKED"
+    case openAndUnlocked = "OPEN_UNLOCKED"
+  }
+}

--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -121,6 +121,13 @@ struct NetworkRoutes {
     )!
   }
 
+  func vehicleLockUnlockLastActionsURL(vin: String) -> URL {
+    return URL(
+      string:
+        "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vin)/last-actions"
+    )!
+  }
+
   func vehicleLockUnlockRemoteCommandStatusURL(
     vin: String, remoteCommand: RemoteCommandAccepted
   ) -> URL {

--- a/Sources/PorscheConnect/PorscheConnect+CarControl.swift
+++ b/Sources/PorscheConnect/PorscheConnect+CarControl.swift
@@ -156,4 +156,17 @@ extension PorscheConnect {
     result.data?.remoteCommand = .unlock
     return (remoteCommandAccepted: result.data, response: result.response)
   }
+
+  public func lockUnlockLastActions(vin: String) async throws -> (
+    lastActions: LockUnlockLastActions?, response: HTTPURLResponse
+  ) {
+    let headers = try await performAuthFor(application: .carControl)
+    let url = networkRoutes.vehicleLockUnlockLastActionsURL(vin: vin)
+
+    let result = try await networkClient.get(
+      LockUnlockLastActions.self, url: url, headers: headers,
+      jsonKeyDecodingStrategy: .useDefaultKeys)
+    return (lastActions: result.data, response: result.response)
+  }
+
 }


### PR DESCRIPTION
This introduces the new endpoint, "last-actions" for the lock/unlock API family. The command now polls the status of the remote command and then prints the "last-actions" result upon completion.