### PR TITLE
Add status checking to the lock command invocation from the CLI.

### DIFF
--- a/Sources/PorscheConnect/Models/LockUnlockLastActions.swift
+++ b/Sources/PorscheConnect/Models/LockUnlockLastActions.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Status of all doors on the car. Meant to be called after initiating a lock/unlock command.
+public struct LockUnlockLastActions: Codable {
+  public let vin: String
+  public let doors: Doors
+  public let rluResult: Int
+  public let bsError: Int
+}

--- a/Sources/PorscheConnect/Models/Overview.swift
+++ b/Sources/PorscheConnect/Models/Overview.swift
@@ -20,6 +20,7 @@ public struct Overview: Codable {
   public let parkingLight: ParkingLight
   public let tires: Tires
   public let windows: Windows
+  public let doors: Doors
   public let serviceIntervals: ServiceIntervals
   public let overallOpenStatus: PhysicalStatus
 

--- a/Sources/PorscheConnect/Models/Subtypes/Doors.swift
+++ b/Sources/PorscheConnect/Models/Subtypes/Doors.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// The status of all doors on the vehicle.
+public struct Doors: Codable {
+  public let frontLeft: DoorStatus
+  public let frontRight: DoorStatus
+  public let backLeft: DoorStatus
+  public let backRight: DoorStatus
+  public let frontTrunk: DoorStatus
+  public let backTrunk: DoorStatus
+  public let overallLockStatus: DoorStatus
+
+  public enum DoorStatus: String, Codable {
+    case closedAndLocked = "CLOSED_LOCKED"
+    case closedAndUnlocked = "CLOSED_UNLOCKED"
+    case openAndUnlocked = "OPEN_UNLOCKED"
+  }
+}

--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -121,6 +121,13 @@ struct NetworkRoutes {
     )!
   }
 
+  func vehicleLockUnlockLastActionsURL(vin: String) -> URL {
+    return URL(
+      string:
+        "\(host("https://api.porsche.com"))/service-vehicle/remote-lock-unlock/\(vin)/last-actions"
+    )!
+  }
+
   func vehicleLockUnlockRemoteCommandStatusURL(
     vin: String, remoteCommand: RemoteCommandAccepted
   ) -> URL {

--- a/Sources/PorscheConnect/PorscheConnect+CarControl.swift
+++ b/Sources/PorscheConnect/PorscheConnect+CarControl.swift
@@ -156,4 +156,17 @@ extension PorscheConnect {
     result.data?.remoteCommand = .unlock
     return (remoteCommandAccepted: result.data, response: result.response)
   }
+
+  public func lockUnlockLastActions(vin: String) async throws -> (
+    lastActions: LockUnlockLastActions?, response: HTTPURLResponse
+  ) {
+    let headers = try await performAuthFor(application: .carControl)
+    let url = networkRoutes.vehicleLockUnlockLastActionsURL(vin: vin)
+
+    let result = try await networkClient.get(
+      LockUnlockLastActions.self, url: url, headers: headers,
+      jsonKeyDecodingStrategy: .useDefaultKeys)
+    return (lastActions: result.data, response: result.response)
+  }
+
 }

--- a/Sources/PorscheConnect/PorscheConnect+RemoteCommandStatus.swift
+++ b/Sources/PorscheConnect/PorscheConnect+RemoteCommandStatus.swift
@@ -3,7 +3,8 @@ import Foundation
 extension PorscheConnect {
 
   public func checkStatus(
-    vehicle: Vehicle, capabilities: Capabilities? = nil,
+    vin: String,
+    capabilities: Capabilities? = nil,
     remoteCommand: RemoteCommandAccepted
   ) async throws -> (
     status: RemoteCommandStatus?, response: HTTPURLResponse?
@@ -12,8 +13,7 @@ extension PorscheConnect {
 
     let result = try await networkClient.get(
       RemoteCommandStatus.self,
-      url: urlForCommand(
-        vehicle: vehicle, capabilities: capabilities, remoteCommand: remoteCommand),
+      url: urlForCommand(vin: vin, capabilities: capabilities, remoteCommand: remoteCommand),
       headers: headers, jsonKeyDecodingStrategy: .useDefaultKeys)
     return (status: result.data, response: result.response)
   }
@@ -21,21 +21,21 @@ extension PorscheConnect {
   // MARK: - Private
 
   private func urlForCommand(
-    vehicle: Vehicle, capabilities: Capabilities?, remoteCommand: RemoteCommandAccepted
+    vin: String, capabilities: Capabilities?, remoteCommand: RemoteCommandAccepted
   ) -> URL {
     switch remoteCommand.remoteCommand {
     case .honkAndFlash:
       return networkRoutes.vehicleHonkAndFlashRemoteCommandStatusURL(
-        vin: vehicle.vin, remoteCommand: remoteCommand)
+        vin: vin, remoteCommand: remoteCommand)
     case .toggleDirectCharge:
       return networkRoutes.vehicleToggleDirectChargingRemoteCommandStatusURL(
-        vin: vehicle.vin, capabilities: capabilities, remoteCommand: remoteCommand)
+        vin: vin, capabilities: capabilities, remoteCommand: remoteCommand)
     case .toggleDirectClimatisation:
       return networkRoutes.vehicleToggleDirectClimatisationRemoteCommandStatusURL(
-        vin: vehicle.vin, remoteCommand: remoteCommand)
+        vin: vin, remoteCommand: remoteCommand)
     case .lock, .unlock:
       return networkRoutes.vehicleLockUnlockRemoteCommandStatusURL(
-        vin: vehicle.vin, remoteCommand: remoteCommand)
+        vin: vin, remoteCommand: remoteCommand)
     case .none:
       return URL(string: kBlankString)!
     }

--- a/Tests/PorscheConnectTests/Public/PorscheConnect+RemoteCommandStatusTests.swift
+++ b/Tests/PorscheConnectTests/Public/PorscheConnect+RemoteCommandStatusTests.swift
@@ -10,7 +10,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
   var connect: PorscheConnect!
   let mockNetworkRoutes = MockNetworkRoutes()
   let application: OAuthApplication = .carControl
-  let vehicle = Vehicle(vin: "A1234")
+  let vin = "A1234"
 
   // MARK: - Lifecycle
 
@@ -38,7 +38,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -60,7 +60,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -82,7 +82,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -108,7 +108,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -130,7 +130,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -152,7 +152,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -178,7 +178,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -200,7 +200,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -222,7 +222,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -248,7 +248,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -270,7 +270,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -292,7 +292,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -318,7 +318,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -340,7 +340,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)
@@ -362,7 +362,7 @@ final class PorscheConnectRemoteCommandStatuslTests: BaseMockNetworkTestCase {
 
     await XCTAsync.XCTAssertFalse(await connect.authorized(application: application))
 
-    let result = try! await connect.checkStatus(vehicle: vehicle, remoteCommand: remoteCommand)
+    let result = try! await connect.checkStatus(vin: vin, remoteCommand: remoteCommand)
 
     expectation.fulfill()
     XCTAssertNotNil(result)


### PR DESCRIPTION
This introduces the new endpoint, "last-actions" for the lock/unlock API family. The command now polls the status of the remote command and then prints the "last-actions" result upon completion.

This is a stacked PR on top of https://github.com/driven-app/porsche-connect/pull/132.