### PR TITLE
Standardize the camera view names.

### DIFF
--- a/Sources/PorscheConnect/APIs/PorscheConnect+Vehicles.swift
+++ b/Sources/PorscheConnect/APIs/PorscheConnect+Vehicles.swift
@@ -56,7 +56,7 @@ public struct Vehicle: Codable {
   public struct VehiclePicture: Codable {
     public init(
       url: URL,
-      view: String,
+      view: CameraView,
       size: Int,
       width: Int,
       height: Int,
@@ -75,7 +75,22 @@ public struct Vehicle: Codable {
     // MARK: Properties
 
     public let url: URL
-    public let view: String
+    public enum CameraView: String, Codable {
+      case front = "extcam01"
+      case side = "extcam02"
+      case rear = "extcam03"
+      case topAngled = "extcam04"
+      case overhead = "extcam05"
+      case dashboard = "intcam01"
+      case cabin = "intcam02"
+      case personalized
+      case unknown
+
+      public init(from decoder: Decoder) throws {
+        self = try CameraView(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+      }
+    }
+    public let view: CameraView
     public let size: Int
     public let width: Int
     public let height: Int

--- a/Tests/PorscheConnectTests/Models/Models+VehicleTests.swift
+++ b/Tests/PorscheConnectTests/Models/Models+VehicleTests.swift
@@ -95,7 +95,7 @@ final class ModelsVehicleTests: XCTestCase {
         string:
           "https://picserv.porsche.com/picserv/images-api/v1/ec2bed3b73260c6f0116e12f538b1ac6/5")!,
       vehiclePicture1.url)
-    XCTAssertEqual("extcam01", vehiclePicture1.view)
+    XCTAssertEqual(.front, vehiclePicture1.view)
     XCTAssertEqual(5, vehiclePicture1.size)
     XCTAssertEqual(1080, vehiclePicture1.height)
     XCTAssertEqual(1920, vehiclePicture1.width)
@@ -109,7 +109,7 @@ final class ModelsVehicleTests: XCTestCase {
         string:
           "https://picserv.porsche.com/picserv/images-api/v1/c11fb8a8bb320523ce6591d52c68f5cf/4")!,
       vehiclePicture2.url)
-    XCTAssertEqual("extcam01", vehiclePicture2.view)
+    XCTAssertEqual(.front, vehiclePicture2.view)
     XCTAssertEqual(4, vehiclePicture2.size)
     XCTAssertEqual(810, vehiclePicture2.height)
     XCTAssertEqual(1440, vehiclePicture2.width)
@@ -123,7 +123,7 @@ final class ModelsVehicleTests: XCTestCase {
         string:
           "https://picserv.porsche.com/picserv/images-api/v1/c11fb8a8bb320523ce6591d52c68f5cf/3")!,
       vehiclePicture3.url)
-    XCTAssertEqual("extcam01", vehiclePicture3.view)
+    XCTAssertEqual(.front, vehiclePicture3.view)
     XCTAssertEqual(3, vehiclePicture3.size)
     XCTAssertEqual(540, vehiclePicture3.height)
     XCTAssertEqual(960, vehiclePicture3.width)
@@ -137,7 +137,7 @@ final class ModelsVehicleTests: XCTestCase {
         string:
           "https://picserv.porsche.com/picserv/images-api/v1/ec2bed3b73260c6f0116e12f538b1ac6/2")!,
       vehiclePicture4.url)
-    XCTAssertEqual("extcam01", vehiclePicture4.view)
+    XCTAssertEqual(.front, vehiclePicture4.view)
     XCTAssertEqual(2, vehiclePicture4.size)
     XCTAssertEqual(360, vehiclePicture4.height)
     XCTAssertEqual(640, vehiclePicture4.width)
@@ -151,7 +151,7 @@ final class ModelsVehicleTests: XCTestCase {
         string:
           "https://picserv.porsche.com/picserv/images-api/v1/ec2bed3b73260c6f0116e12f538b1ac6/1")!,
       vehiclePicture5.url)
-    XCTAssertEqual("extcam01", vehiclePicture5.view)
+    XCTAssertEqual(.front, vehiclePicture5.view)
     XCTAssertEqual(1, vehiclePicture5.size)
     XCTAssertEqual(72, vehiclePicture5.height)
     XCTAssertEqual(128, vehiclePicture5.width)


### PR DESCRIPTION
Note that there's a risk that the chosen enum names won't match up with the camera angles in the future or with other cars.