### PR TITLE
Add a pictures endpoint.

### DIFF
--- a/Sources/PorscheConnect/APIs/PorscheConnect+Pictures.swift
+++ b/Sources/PorscheConnect/APIs/PorscheConnect+Pictures.swift
@@ -1,0 +1,22 @@
+import CoreLocation
+import Foundation
+
+extension PorscheConnect {
+  public func pictures(vin: String) async throws -> (
+    pictures: Pictures?, response: HTTPURLResponse
+  ) {
+    let headers = try await performAuthFor(application: .api)
+
+    let result = try await networkClient.get(
+      Pictures.self, url: networkRoutes.vehiclePicturesURL(vin: vin), headers: headers,
+      jsonKeyDecodingStrategy: .useDefaultKeys)
+    return (pictures: result.data, response: result.response)
+  }
+}
+
+// MARK: - Response types
+
+public struct Pictures: Codable {
+  public let vin: String
+  public let pictures: [Picture]
+}

--- a/Sources/PorscheConnect/APIs/PorscheConnect+Vehicles.swift
+++ b/Sources/PorscheConnect/APIs/PorscheConnect+Vehicles.swift
@@ -26,7 +26,9 @@ public struct Vehicle: Codable {
   public let exteriorColor: String?
   public let exteriorColorHex: String?
   public let attributes: [VehicleAttribute]?
-  public let pictures: [VehiclePicture]?
+
+  // This property was moved to the PorscheConnect+Pictures endpoint as of May 2023.
+  public let pictures: [Picture]?
 
   // MARK: Computed Properties
 
@@ -51,59 +53,12 @@ public struct Vehicle: Codable {
     public let value: String
   }
 
-  // MARK: -
-
-  public struct VehiclePicture: Codable {
-    public init(
-      url: URL,
-      view: CameraView,
-      size: Int,
-      width: Int,
-      height: Int,
-      transparent: Bool,
-      placeholder: String? = nil
-    ) {
-      self.url = url
-      self.view = view
-      self.size = size
-      self.width = width
-      self.height = height
-      self.transparent = transparent
-      self.placeholder = placeholder
-    }
-
-    // MARK: Properties
-
-    public let url: URL
-    public enum CameraView: String, Codable {
-      case front = "extcam01"
-      case side = "extcam02"
-      case rear = "extcam03"
-      case topAngled = "extcam04"
-      case overhead = "extcam05"
-      case dashboard = "intcam01"
-      case cabin = "intcam02"
-      case personalized
-      case unknown
-
-      public init(from decoder: Decoder) throws {
-        self = try CameraView(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
-      }
-    }
-    public let view: CameraView
-    public let size: Int
-    public let width: Int
-    public let height: Int
-    public let transparent: Bool
-    public let placeholder: String?
-  }
-
   // MARK: - Public
 
   public init(
     vin: String, modelDescription: String, modelType: String, modelYear: String,
     exteriorColor: String?, exteriorColorHex: String?, attributes: [VehicleAttribute]?,
-    pictures: [VehiclePicture]?
+    pictures: [Picture]?
   ) {
     self.vin = vin
     self.modelDescription = modelDescription

--- a/Sources/PorscheConnect/CommonResponseObjects/Picture.swift
+++ b/Sources/PorscheConnect/CommonResponseObjects/Picture.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+public struct Picture: Codable {
+  public init(
+    url: URL,
+    view: CameraView,
+    size: Int,
+    width: Int,
+    height: Int,
+    transparent: Bool,
+    placeholder: String? = nil,
+    environment: String? = nil
+  ) {
+    self.url = url
+    self.view = view
+    self.size = size
+    self.width = width
+    self.height = height
+    self.transparent = transparent
+    self.placeholder = placeholder
+    self.environment = environment
+  }
+
+  // MARK: Properties
+
+  public let url: URL
+  public enum CameraView: String, Codable {
+    case front = "extcam01"
+    case side = "extcam02"
+    case rear = "extcam03"
+    case topAngled = "extcam04"
+    case overhead = "extcam05"
+    case dashboard = "intcam01"
+    case cabin = "intcam02"
+    case personalized
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+      self = try CameraView(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+    }
+  }
+  public let view: CameraView
+  public let size: Int
+  public let width: Int
+  public let height: Int
+  public let transparent: Bool
+  public let placeholder: String?
+
+  /// Known values include:
+  /// - studio
+  public let environment: String?
+}

--- a/Sources/PorscheConnect/NetworkRoutes.swift
+++ b/Sources/PorscheConnect/NetworkRoutes.swift
@@ -33,6 +33,11 @@ struct NetworkRoutes {
       string: "\(host("https://api.porsche.com"))/service-vehicle/vehicle-summary/\(vin)")!
   }
 
+  func vehiclePicturesURL(vin: String) -> URL {
+    return URL(
+      string: "\(host("https://api.porsche.com"))/vehicles/v2/\(environment.countryCode)/\(vin)/pictures")!
+  }
+
   func vehiclePositionURL(vin: String) -> URL {
     return URL(
       string:


### PR DESCRIPTION
Porsche appears to have pulled the pictures data out of the vehicles endpoint into a separate endpoint per-vehicle. This makes sense as the pictures data is ~40kb / vehicle, vs the ~1kb of vehicle info otherwise returned by the vehicles endpoint.

This PR adds the new pictures endpoint to the routes and model.